### PR TITLE
Remove `Uint` trait, add saturating ops

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ homepage = "http://parity.io"
 repository = "https://github.com/ethcore/bigint"
 license = "GPL-3.0"
 name = "bigint"
-version = "1.0.2"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 build = "build.rs"
 


### PR DESCRIPTION
`Uint` is a nuisance, and saturating ops would be nice for a bunch of things (EIP198, request credit calculations)

Have to bump the version to 2.0.0 because it's backwards-incompatible. Alternatively, we could keep the `Uint` trait but not require it. I think it makes more sense to remove it and then add `Num` support in a future `2.0.x` version.