### PR TITLE
bump heapsize crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ homepage = "http://parity.io"
 repository = "https://github.com/ethcore/bigint"
 license = "MIT/Apache-2.0"
 name = "bigint"
-version = "2.0.1"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 build = "build.rs"
 
@@ -13,6 +13,6 @@ rustc_version = "0.2"
 
 [dependencies]
 rustc-serialize = "0.3"
-heapsize = "0.3"
+heapsize = "0.4"
 rand = "0.3"
 byteorder = "1.0"


### PR DESCRIPTION
Required to fix a Parity issue, I figure it's time to bite the bullet and publish version 2.0.0, integrate it, and kill the Uint trait.