### PR TITLE
make heapsize optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,6 @@ rust:
 matrix:
   allow_failures:
     - rust: nightly
+script:
+  - cargo build --features "heapsizeof"
+  - cargo test --features "heapsizeof"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ homepage = "http://parity.io"
 repository = "https://github.com/ethcore/bigint"
 license = "MIT/Apache-2.0"
 name = "bigint"
-version = "2.0.0"
+version = "3.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 build = "build.rs"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,9 @@ build = "build.rs"
 rustc_version = "0.2"
 
 [dependencies]
-rustc-serialize = "0.3"
-heapsize = "0.4"
-rand = "0.3"
+rustc-hex = "1.0"
 byteorder = "1.0"
+heapsize = { version = "0.4", optional = true }
+
+[features]
+heapsizeof = ["heapsize"]

--- a/benches/bigint.rs
+++ b/benches/bigint.rs
@@ -1,0 +1,103 @@
+// Copyright 2015-2017 Parity Technologies
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! benchmarking for bigint
+//! should be started with:
+//! ```bash
+//! rustup run nightly cargo bench
+//! ```
+
+#![feature(test)]
+#![feature(asm)]
+
+extern crate test;
+extern crate bigint;
+
+use test::{Bencher, black_box};
+use bigint::{U256, U512, U128};
+
+#[bench]
+fn u256_add(b: &mut Bencher) {
+	b.iter(|| {
+		let n = black_box(10000);
+		let zero = black_box(U256::zero());
+		(0..n).fold(zero, |old, new| { old.overflowing_add(U256::from(black_box(new))).0 })
+	});
+}
+
+#[bench]
+fn u256_sub(b: &mut Bencher) {
+	b.iter(|| {
+		let n = black_box(10000);
+		let max = black_box(U256::max_value());
+		(0..n).fold(max, |old, new| { old.overflowing_sub(U256::from(black_box(new))).0 })
+	});
+}
+
+#[bench]
+fn u512_sub(b: &mut Bencher) {
+	b.iter(|| {
+		let n = black_box(10000);
+		let max = black_box(U512::max_value());
+		(0..n).fold(
+			max,
+			|old, new| {
+				let new = black_box(new);
+				let p = new % 2;
+				old.overflowing_sub(U512([p, p, p, p, p, p, p, new])).0
+			}
+		)
+	});
+}
+
+#[bench]
+fn u512_add(b: &mut Bencher) {
+	b.iter(|| {
+		let n = black_box(10000);
+		let zero = black_box(U512::zero());
+		(0..n).fold(zero,
+			|old, new| {
+				let new = black_box(new);
+				old.overflowing_add(U512([new, new, new, new, new, new, new, new])).0
+			})
+	});
+}
+
+#[bench]
+fn u256_mul(b: &mut Bencher) {
+	b.iter(|| {
+		let n = black_box(10000);
+		let one = black_box(U256::one());
+		(0..n).fold(one, |old, new| { old.overflowing_mul(U256::from(black_box(new))).0 })
+	});
+}
+
+
+#[bench]
+fn u256_full_mul(b: &mut Bencher) {
+	b.iter(|| {
+		let n = black_box(10000);
+		let one = black_box(U256::one());
+		(0..n).fold(one,
+			|old, new| {
+				let new = black_box(new);
+				let U512(ref u512words) = old.full_mul(U256([new, new, new, new]));
+				U256([u512words[0], u512words[2], u512words[2], u512words[3]])
+			})
+	});
+}
+
+
+#[bench]
+fn u128_mul(b: &mut Bencher) {
+	b.iter(|| {
+		let n = black_box(10000);
+		(0..n).fold(U128([12345u64, 0u64]), |old, new| { old.overflowing_mul(U128::from(new)).0 })
+	});
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,9 +11,11 @@
 #![cfg_attr(asm_available, feature(asm))]
 
 extern crate byteorder;
-extern crate rand;
-extern crate rustc_serialize;
-#[macro_use] extern crate heapsize;
+extern crate rustc_hex;
+
+#[cfg(feature="heapsizeof")]
+#[macro_use] 
+extern crate heapsize;
 
 pub mod uint;
 pub use ::uint::*;

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -29,12 +29,11 @@
 //! implementations for even more speed, hidden behind the `x64_arithmetic`
 //! feature flag.
 
-use std::{fmt, cmp};
-use std::str::{FromStr};
+use std::{fmt, cmp, str};
 use std::ops::{Shr, Shl, BitAnd, BitOr, BitXor, Not, Div, Rem, Mul, Add, Sub};
 use std::cmp::Ordering;
 use byteorder::{ByteOrder, BigEndian, LittleEndian};
-use rustc_serialize::hex::{ToHex, FromHex, FromHexError};
+use rustc_hex::{ToHex, FromHex, FromHexError};
 
 /// Conversion from decimal string error
 #[derive(Debug, PartialEq)]
@@ -850,7 +849,7 @@ macro_rules! construct_uint {
 			}
 		}
 
-		impl FromStr for $name {
+		impl str::FromStr for $name {
 			type Err = FromHexError;
 
 			fn from_str(value: &str) -> Result<$name, Self::Err> {
@@ -1419,6 +1418,7 @@ impl From<U256> for u32 {
 	}
 }
 
+#[cfg(feature="heapsizeof")]
 known_heap_size!(0, U128, U256);
 
 #[cfg(test)]


### PR DESCRIPTION
changes:
- moved benches from parity repo
- added feature gate 'heapsizeof'
- replaced deprecated `rustc_serialize` with `rustc_hex`
- removed unused `rand` dependency
- bumped version to `3.0.0`

related: https://github.com/paritytech/parity/issues/5964