### PR TITLE
custom serde serialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 .idea
 Cargo.lock
+*.swp

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,11 @@ rustc_version = "0.2"
 rustc-hex = "1.0"
 byteorder = "1.0"
 heapsize = { version = "0.4", optional = true }
+serde = { version = "1.0", optional = true }
 
 [features]
 heapsizeof = ["heapsize"]
+
+[dev-dependencies]
+serde_derive = "1.0"
+toml = "0.4"

--- a/src/heapsize.rs
+++ b/src/heapsize.rs
@@ -1,0 +1,3 @@
+use {U128, U256, U512};
+
+known_heap_size!(0, U128, U256, U512);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,9 +13,18 @@
 extern crate byteorder;
 extern crate rustc_hex;
 
-#[cfg(feature="heapsizeof")]
+#[cfg(feature="heapsize")]
 #[macro_use] 
-extern crate heapsize;
+extern crate heapsize as _heapsize;
 
-pub mod uint;
-pub use ::uint::*;
+#[cfg(feature="heapsize")]
+mod heapsize;
+
+#[cfg(feature="serde")]
+extern crate serde;
+
+#[cfg(feature="serde")]
+pub mod serialization;
+
+mod uint;
+pub use uint::{U128, U256, U512};

--- a/src/serialization/decimal.rs
+++ b/src/serialization/decimal.rs
@@ -1,0 +1,66 @@
+//! Decimal serialization for bigint
+
+use std::{fmt, marker};
+use serde::{Serializer, Deserializer};
+use serde::de::{Error, Visitor};
+use {U128, U256, U512};
+
+pub trait DecimalSerializable {
+	fn to_decimal(&self) -> String;
+
+	fn from_decimal<E>(value: &str) -> Result<Self, E> where Self: Sized, E: Error;
+}
+
+macro_rules! impl_decimal_serializable {
+	($($type: ident),+) => (
+		$(
+			impl DecimalSerializable for $type {
+				fn to_decimal(&self) -> String {
+					self.to_string()
+				}
+
+				fn from_decimal<E>(value: &str) -> Result<Self, E> where E: Error {
+					Self::from_dec_str(value).map_err(|e| E::custom(&format!("{:?}", e)))
+				}
+			}
+		)+
+	)
+}
+
+impl_decimal_serializable!(U128, U256, U512);
+
+pub fn serialize<U, S>(u: &U, serializer: S) -> Result<S::Ok, S::Error> where U: DecimalSerializable, S: Serializer {
+	serializer.serialize_str(&u.to_decimal())
+}
+
+pub fn deserialize<'de, U, D>(deserializer: D) -> Result<U, D::Error> where U: DecimalSerializable, D: Deserializer<'de> {
+	deserializer.deserialize_any(UintVisitor::new())
+}
+
+struct UintVisitor<U> {
+	marker: marker::PhantomData<U>,
+}
+
+impl<U> UintVisitor<U> {
+	fn new() -> Self {
+		UintVisitor {
+			marker: marker::PhantomData,
+		}
+	}
+}
+
+impl<'de, U> Visitor<'de> for UintVisitor<U> where U: DecimalSerializable {
+	type Value = U;
+
+	fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+		write!(formatter, "hex-encoded number")
+	}
+
+	fn visit_str<E>(self, value: &str) -> Result<Self::Value, E> where E: Error {
+		U::from_decimal(value)
+	}
+
+	fn visit_string<E>(self, value: String) -> Result<Self::Value, E> where E: Error {
+		self.visit_str(&value)
+	}
+}

--- a/src/serialization/hex.rs
+++ b/src/serialization/hex.rs
@@ -1,0 +1,66 @@
+//! Hex serialization for bigint
+
+use std::{fmt, marker};
+use serde::{Serializer, Deserializer};
+use serde::de::{Error, Visitor};
+use {U128, U256, U512};
+
+pub trait HexSerializable {
+	fn to_hex(&self) -> String;
+
+	fn from_hex<E>(value: &str) -> Result<Self, E> where Self: Sized, E: Error;
+}
+
+macro_rules! impl_hex_serializable {
+	($($type: ident),+) => (
+		$(
+			impl HexSerializable for $type {
+				fn to_hex(&self) -> String {
+					self.to_hex()
+				}
+
+				fn from_hex<E>(value: &str) -> Result<Self, E> where E: Error {
+					value.parse().map_err(|e| E::custom(&format!("{:?}", e)))
+				}
+			}
+		)+
+	)
+}
+
+impl_hex_serializable!(U128, U256, U512);
+
+pub fn serialize<U, S>(u: &U, serializer: S) -> Result<S::Ok, S::Error> where U: HexSerializable, S: Serializer {
+	serializer.serialize_str(&u.to_hex())
+}
+
+pub fn deserialize<'de, U, D>(deserializer: D) -> Result<U, D::Error> where U: HexSerializable, D: Deserializer<'de> {
+	deserializer.deserialize_any(UintVisitor::new())
+}
+
+struct UintVisitor<U> {
+	marker: marker::PhantomData<U>,
+}
+
+impl<U> UintVisitor<U> {
+	fn new() -> Self {
+		UintVisitor {
+			marker: marker::PhantomData,
+		}
+	}
+}
+
+impl<'de, U> Visitor<'de> for UintVisitor<U> where U: HexSerializable {
+	type Value = U;
+
+	fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+		write!(formatter, "hex-encoded number")
+	}
+
+	fn visit_str<E>(self, value: &str) -> Result<Self::Value, E> where E: Error {
+		U::from_hex(value)
+	}
+
+	fn visit_string<E>(self, value: String) -> Result<Self::Value, E> where E: Error {
+		self.visit_str(&value)
+	}
+}

--- a/src/serialization/hex_prefixed.rs
+++ b/src/serialization/hex_prefixed.rs
@@ -1,0 +1,69 @@
+//! Hex serialization for bigint
+
+use std::{fmt, marker};
+use serde::{Serializer, Deserializer};
+use serde::de::{Error, Visitor};
+use {U128, U256, U512};
+
+pub trait HexPrefixedSerializable {
+	fn to_hex(&self) -> String;
+
+	fn from_hex<E>(value: &str) -> Result<Self, E> where Self: Sized, E: Error;
+}
+
+macro_rules! impl_hex_prefixed_serializable {
+	($($type: ident),+) => (
+		$(
+			impl HexPrefixedSerializable for $type {
+				fn to_hex(&self) -> String {
+					"0x".to_owned() + &self.to_hex()
+				}
+
+				fn from_hex<E>(value: &str) -> Result<Self, E> where E: Error {
+					match value.len() {
+						2 if &value[0..2] == "0x" => value[2..].parse().map_err(|e| E::custom(&format!("{:?}", e))),
+						_ => Err(E::custom("expected hex prefixed value")),
+					}
+				}
+			}
+		)+
+	)
+}
+
+impl_hex_prefixed_serializable!(U128, U256, U512);
+
+pub fn serialize<U, S>(u: &U, serializer: S) -> Result<S::Ok, S::Error> where U: HexPrefixedSerializable, S: Serializer {
+	serializer.serialize_str(&u.to_hex())
+}
+
+pub fn deserialize<'de, U, D>(deserializer: D) -> Result<U, D::Error> where U: HexPrefixedSerializable, D: Deserializer<'de> {
+	deserializer.deserialize_any(UintVisitor::new())
+}
+
+struct UintVisitor<U> {
+	marker: marker::PhantomData<U>,
+}
+
+impl<U> UintVisitor<U> {
+	fn new() -> Self {
+		UintVisitor {
+			marker: marker::PhantomData,
+		}
+	}
+}
+
+impl<'de, U> Visitor<'de> for UintVisitor<U> where U: HexPrefixedSerializable {
+	type Value = U;
+
+	fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+		write!(formatter, "hex-encoded number")
+	}
+
+	fn visit_str<E>(self, value: &str) -> Result<Self::Value, E> where E: Error {
+		U::from_hex(value)
+	}
+
+	fn visit_string<E>(self, value: String) -> Result<Self::Value, E> where E: Error {
+		self.visit_str(&value)
+	}
+}

--- a/src/serialization/hex_prefixed.rs
+++ b/src/serialization/hex_prefixed.rs
@@ -20,9 +20,10 @@ macro_rules! impl_hex_prefixed_serializable {
 				}
 
 				fn from_hex<E>(value: &str) -> Result<Self, E> where E: Error {
-					match value.len() {
-						2 if &value[0..2] == "0x" => value[2..].parse().map_err(|e| E::custom(&format!("{:?}", e))),
-						_ => Err(E::custom("expected hex prefixed value")),
+					if value.len() > 2 && &value[0..2] == "0x" {
+						value[2..].parse().map_err(|e| E::custom(&format!("{:?}", e)))
+					} else {
+						Err(E::custom("expected hex prefixed value"))
 					}
 				}
 			}

--- a/src/serialization/lenient.rs
+++ b/src/serialization/lenient.rs
@@ -1,0 +1,51 @@
+//! Hex serialization for bigint
+
+use std::{fmt, marker};
+use serde::{Serializer, Deserializer};
+use serde::de::{Error, Visitor};
+use serialization::decimal::DecimalSerializable;
+use serialization::hex_prefixed::HexPrefixedSerializable;
+
+pub fn serialize<U, S>(u: &U, serializer: S) -> Result<S::Ok, S::Error> where U: HexPrefixedSerializable, S: Serializer {
+	serializer.serialize_str(&u.to_hex())
+}
+
+pub fn deserialize<'de, U, D>(deserializer: D) -> Result<U, D::Error> where U: DecimalSerializable + HexPrefixedSerializable + From<u64>, D: Deserializer<'de> {
+	deserializer.deserialize_any(UintVisitor::new())
+}
+
+struct UintVisitor<U> {
+	marker: marker::PhantomData<U>,
+}
+
+impl<U> UintVisitor<U> {
+	fn new() -> Self {
+		UintVisitor {
+			marker: marker::PhantomData,
+		}
+	}
+}
+
+impl<'de, U> Visitor<'de> for UintVisitor<U> where U: HexPrefixedSerializable + DecimalSerializable + From<u64> {
+	type Value = U;
+
+	fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+		write!(formatter, "hex-encoded number")
+	}
+	
+	fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E> where E: Error {
+		Ok(U::from(value as u64))
+	}
+
+	fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E> where E: Error {
+		Ok(U::from(value))
+	}
+
+	fn visit_str<E>(self, value: &str) -> Result<Self::Value, E> where E: Error {
+		U::from_hex(value).or_else(|_: E| U::from_decimal(value))
+	}
+
+	fn visit_string<E>(self, value: String) -> Result<Self::Value, E> where E: Error {
+		self.visit_str(&value)
+	}
+}

--- a/src/serialization/mod.rs
+++ b/src/serialization/mod.rs
@@ -3,3 +3,4 @@
 pub mod decimal;
 pub mod hex;
 pub mod hex_prefixed;
+pub mod lenient;

--- a/src/serialization/mod.rs
+++ b/src/serialization/mod.rs
@@ -1,0 +1,5 @@
+//! Various serialization policies for bigint crate
+
+pub mod decimal;
+pub mod hex;
+pub mod hex_prefixed;

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -1418,9 +1418,6 @@ impl From<U256> for u32 {
 	}
 }
 
-#[cfg(feature="heapsizeof")]
-known_heap_size!(0, U128, U256);
-
 #[cfg(test)]
 mod tests {
 	use uint::{U128, U256, U512};

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -15,7 +15,7 @@ mod tests {
 	use toml;
 	use bigint;
 	
-	#[derive(Serialize, Deserialize)]
+	#[derive(Serialize, Deserialize, Debug, PartialEq)]
 	struct TestHex {
 		// hex serialization
 		#[serde(with = "bigint::serialization::hex")]
@@ -41,9 +41,10 @@ uint512 = "fff"
 "#;
 
 		assert_eq!(expected, toml::to_string(&v).unwrap());
+		assert_eq!(v, toml::from_str(expected).unwrap());
 	}
 
-	#[derive(Serialize, Deserialize)]
+	#[derive(Serialize, Deserialize, Debug, PartialEq)]
 	struct TestHexPrefixed {
 		// hex prefixed serialization
 		#[serde(with = "bigint::serialization::hex_prefixed")]
@@ -69,9 +70,10 @@ uint512 = "0xfff"
 "#;
 
 		assert_eq!(expected, toml::to_string(&v).unwrap());
+		assert_eq!(v, toml::from_str(expected).unwrap());
 	}
 
-	#[derive(Serialize, Deserialize)]
+	#[derive(Serialize, Deserialize, Debug, PartialEq)]
 	struct TestDecimal {	
 		// decimal serialization
 		#[serde(with = "bigint::serialization::decimal")]
@@ -97,5 +99,42 @@ uint512 = "4095"
 "#;
 
 		assert_eq!(expected, toml::to_string(&v).unwrap());
+		assert_eq!(v, toml::from_str(expected).unwrap());
+	}
+
+	#[derive(Serialize, Deserialize, Debug, PartialEq)]
+	struct TestLenient {	
+		// decimal serialization
+		#[serde(with = "bigint::serialization::lenient")]
+		uint128: bigint::U128,
+		#[serde(with = "bigint::serialization::lenient")]
+		uint256: bigint::U256,
+		#[serde(with = "bigint::serialization::lenient")]
+		uint512: bigint::U512,
+	}
+
+	#[test]
+	fn test_lenient() {
+		let v = TestLenient {
+			uint128: 0.into(),
+			uint256: 10.into(),
+			uint512: 0xfff.into(),
+		};
+
+		let expected = 
+r#"uint128 = "0x0"
+uint256 = "0xa"
+uint512 = "0xfff"
+"#;
+
+		let test_str =
+r#"uint128 = 0
+uint256 = "10"
+uint512 = "0xfff"
+"#;
+
+		assert_eq!(expected, toml::to_string(&v).unwrap());
+		assert_eq!(v, toml::from_str(expected).unwrap());
+		assert_eq!(v, toml::from_str(test_str).unwrap());
 	}
 }

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -1,0 +1,101 @@
+extern crate bigint;
+
+#[cfg(feature="serde")]
+extern crate serde;
+
+#[cfg(feature="serde")]
+#[macro_use]
+extern crate serde_derive;
+
+#[cfg(feature="serde")]
+extern crate toml;
+
+#[cfg(feature="serde")]
+mod tests {
+	use toml;
+	use bigint;
+	
+	#[derive(Serialize, Deserialize)]
+	struct TestHex {
+		// hex serialization
+		#[serde(with = "bigint::serialization::hex")]
+		uint128: bigint::U128,
+		#[serde(with = "bigint::serialization::hex")]
+		uint256: bigint::U256,
+		#[serde(with = "bigint::serialization::hex")]
+		uint512: bigint::U512,
+	}
+
+	#[test]
+	fn test_hex() {
+		let v = TestHex {
+			uint128: 0.into(),
+			uint256: 10.into(),
+			uint512: 0xfff.into(),
+		};
+
+		let expected = 
+r#"uint128 = "0"
+uint256 = "a"
+uint512 = "fff"
+"#;
+
+		assert_eq!(expected, toml::to_string(&v).unwrap());
+	}
+
+	#[derive(Serialize, Deserialize)]
+	struct TestHexPrefixed {
+		// hex prefixed serialization
+		#[serde(with = "bigint::serialization::hex_prefixed")]
+		uint128: bigint::U128,
+		#[serde(with = "bigint::serialization::hex_prefixed")]
+		uint256: bigint::U256,
+		#[serde(with = "bigint::serialization::hex_prefixed")]
+		uint512: bigint::U512,
+	}
+
+	#[test]
+	fn test_hex_prefixed() {
+		let v = TestHexPrefixed {
+			uint128: 0.into(),
+			uint256: 10.into(),
+			uint512: 0xfff.into(),
+		};
+
+		let expected = 
+r#"uint128 = "0x0"
+uint256 = "0xa"
+uint512 = "0xfff"
+"#;
+
+		assert_eq!(expected, toml::to_string(&v).unwrap());
+	}
+
+	#[derive(Serialize, Deserialize)]
+	struct TestDecimal {	
+		// decimal serialization
+		#[serde(with = "bigint::serialization::decimal")]
+		uint128: bigint::U128,
+		#[serde(with = "bigint::serialization::decimal")]
+		uint256: bigint::U256,
+		#[serde(with = "bigint::serialization::decimal")]
+		uint512: bigint::U512,
+	}
+
+	#[test]
+	fn test_decimal() {
+		let v = TestDecimal {
+			uint128: 0.into(),
+			uint256: 10.into(),
+			uint512: 0xfff.into(),
+		};
+
+		let expected = 
+r#"uint128 = "0"
+uint256 = "10"
+uint512 = "4095"
+"#;
+
+		assert_eq!(expected, toml::to_string(&v).unwrap());
+	}
+}


### PR DESCRIPTION
Reimplementing/wrapping uint and hash is super annoying and we did it already several times. This pr implements custom serialization for uint using serde. Wrapper types won't be needed

cc @rphmeier @gavofyork 

**don't merge**