### PR TITLE
Add no_std support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ matrix:
   allow_failures:
     - rust: nightly
 script:
-  - cargo build --features "heapsizeof"
-  - cargo test --features "heapsizeof"
+  - cargo build --features=heapsizeof,std
+  - cargo test --features=heapsizeof,std

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,14 @@ build = "build.rs"
 rustc_version = "0.2"
 
 [dependencies]
-rustc-hex = "1.0"
+rustc-hex = { version = "1.0", optional = true }
 heapsize = { version = "0.4", optional = true }
 byteorder = { version = "1", default-features = false }
 
 [features]
 heapsizeof = ["heapsize", "std"]
-std = []
+std = ["rustc-hex"]
+
+[[example]]
+name = "modular"
+required-features = ["std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ rustc_version = "0.2"
 
 [dependencies]
 rustc-hex = "1.0"
-byteorder = "1.0"
 heapsize = { version = "0.4", optional = true }
+byteorder = { version = "1", default-features = false }
 
 [features]
 heapsizeof = ["heapsize", "std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,5 @@ byteorder = "1.0"
 heapsize = { version = "0.4", optional = true }
 
 [features]
-heapsizeof = ["heapsize"]
+heapsizeof = ["heapsize", "std"]
+std = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,12 +10,19 @@
 
 #![cfg_attr(asm_available, feature(asm))]
 
+#![cfg_attr(not(feature="std"), no_std)]
+
 extern crate byteorder;
+
+#[cfg(feature="std")]
 extern crate rustc_hex;
 
 #[cfg(feature="heapsizeof")]
-#[macro_use] 
+#[macro_use]
 extern crate heapsize;
+
+#[cfg(feature="std")]
+extern crate core;
 
 pub mod uint;
 pub use ::uint::*;

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -1433,7 +1433,7 @@ impl From<U256> for u32 {
 known_heap_size!(0, U128, U256);
 
 #[cfg(test)]
-#[cfg(std)]
+#[cfg(feature="std")]
 mod tests {
 	use uint::{U128, U256, U512};
 	use std::str::FromStr;

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -29,7 +29,7 @@
 //! implementations for even more speed, hidden behind the `x64_arithmetic`
 //! feature flag.
 
-use core::{str};
+use core::str;
 use core::ops::{Shr, Shl, BitAnd, BitOr, BitXor, Not, Div, Rem, Mul, Add, Sub};
 
 use byteorder::{ByteOrder, BigEndian, LittleEndian};

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -1433,6 +1433,7 @@ impl From<U256> for u32 {
 known_heap_size!(0, U128, U256);
 
 #[cfg(test)]
+#[cfg(std)]
 mod tests {
 	use uint::{U128, U256, U512};
 	use std::str::FromStr;


### PR DESCRIPTION
This allows to use crate in `no_std` enviroments

Just add dependency as `bigint = { version = "3", default-features = false }`