### PR TITLE
mul and from optimizations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 .idea
 Cargo.lock
+*.swp

--- a/benches/bigint.rs
+++ b/benches/bigint.rs
@@ -101,3 +101,28 @@ fn u128_mul(b: &mut Bencher) {
 	});
 }
 
+#[bench]
+fn u256_from_le(b: &mut Bencher) {
+	b.iter(|| {
+		let raw = black_box([
+			1u8, 2, 3, 5, 7, 11, 13, 17,
+			19, 23, 29, 31, 37, 41, 43, 47,
+			53, 59, 61, 67, 71, 73, 79, 83,
+			89, 97, 101, 103, 107, 109, 113, 127
+		]);
+		let _ = U256::from_little_endian(&raw[..]);
+	});
+}
+
+#[bench]
+fn u256_from_be(b: &mut Bencher) {
+	b.iter(|| {
+		let raw = black_box([
+			1u8, 2, 3, 5, 7, 11, 13, 17,
+			19, 23, 29, 31, 37, 41, 43, 47,
+			53, 59, 61, 67, 71, 73, 79, 83,
+			89, 97, 101, 103, 107, 109, 113, 127
+		]);
+		let _ = U256::from_big_endian(&raw[..]);
+	});
+}

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -2427,4 +2427,32 @@ mod tests {
 
 		assert_eq!(raw, new_raw);
 	}
+
+	#[test]
+	fn from_little_endian() {
+		let source: [u8; 32] = [
+			1, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0,
+		];
+
+		let number = U256::from_little_endian(&source[..]);
+
+		assert_eq!(U256::from(1), number);
+	}
+
+	#[test]
+	fn from_big_endian() {
+		let source: [u8; 32] = [
+			0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 1,
+		];
+
+		let number = U256::from_big_endian(&source[..]);
+
+		assert_eq!(U256::from(1), number);
+	}
  }


### PR DESCRIPTION
- mul is ~30% faster
- from_little_endian / from_big_endian is ~80% faster 

before:

```
test u128_mul      ... bench:     151,032 ns/iter (+/- 32,331)
test u256_from_be  ... bench:          57 ns/iter (+/- 0)
test u256_from_le  ... bench:           51 ns/iter (+/- 1)
test u256_full_mul ... bench:     228,725 ns/iter (+/- 30,183)
test u256_mul      ... bench:     123,390 ns/iter (+/- 32,967)
```

after: 

```
test u128_mul      ... bench:      98,213 ns/iter (+/- 13,330)
test u256_from_be  ... bench:          13 ns/iter (+/- 0)
test u256_from_le  ... bench:           7 ns/iter (+/- 0)
test u256_full_mul ... bench:     199,849 ns/iter (+/- 19,195)
test u256_mul      ... bench:     105,883 ns/iter (+/- 14,433)
```

pleasereview @NikVolf / @Vurich 