### PR TITLE
Optimization improvements

### DIFF
--- a/benches/bigint.rs
+++ b/benches/bigint.rs
@@ -73,7 +73,7 @@ fn u512_mul(b: &mut Bencher) {
 	b.iter(|| {
 		let n = black_box(10000);
 		let one = black_box(U512::one());
-		(1..n).fold(one, |old, new| { old.overflowing_mul(U512::from(black_box(new))).0 })
+		(1..n).fold(one, |old, new| { old.overflowing_mul(U512::from(black_box(new | 1))).0 })
 	});
 }
 
@@ -82,7 +82,7 @@ fn u256_mul(b: &mut Bencher) {
 	b.iter(|| {
 		let n = black_box(10000);
 		let one = black_box(U256::one());
-		(1..n).fold(one, |old, new| { old.overflowing_mul(U256::from(black_box(new))).0 })
+		(1..n).fold(one, |old, new| { old.overflowing_mul(U256::from(black_box(new | 1))).0 })
 	});
 }
 
@@ -91,7 +91,7 @@ fn u256_full_mul(b: &mut Bencher) {
 	b.iter(|| {
 		let n = black_box(10000);
 		let one = black_box(U256::one());
-		(1..n).fold(one,
+		(1..n).map(|n| n | 1).fold(one,
 			|old, new| {
 				let new = black_box(new);
 				let U512(ref u512words) = old.full_mul(U256([new, new, new, new]));
@@ -105,7 +105,7 @@ fn u256_full_mul(b: &mut Bencher) {
 fn u128_mul(b: &mut Bencher) {
 	b.iter(|| {
 		let n = black_box(10000);
-		(1..n).fold(U128([12345u64, 0u64]), |old, new| { old.overflowing_mul(U128::from(new)).0 })
+		(1..n).fold(U128([12345u64, 0u64]), |old, new| { old.overflowing_mul(U128::from(new | 1)).0 })
 	});
 }
 

--- a/benches/bigint.rs
+++ b/benches/bigint.rs
@@ -78,11 +78,29 @@ fn u512_mul(b: &mut Bencher) {
 }
 
 #[bench]
+fn u512_mul_small(b: &mut Bencher) {
+	b.iter(|| {
+		let n = black_box(10000);
+		let one = black_box(U512::one());
+		(1..153).fold(one, |old, new| { old.overflowing_mul(U512::from(10)).0 })
+	});
+}
+
+#[bench]
 fn u256_mul(b: &mut Bencher) {
 	b.iter(|| {
 		let n = black_box(10000);
 		let one = black_box(U256::one());
 		(1..n).fold(one, |old, new| { old.overflowing_mul(U256::from(black_box(new | 1))).0 })
+	});
+}
+
+#[bench]
+fn u256_mul_small(b: &mut Bencher) {
+	b.iter(|| {
+		let n = black_box(10000);
+		let one = black_box(U256::one());
+		(1..77).fold(one, |old, new| { old.overflowing_mul(U256::from(10)).0 })
 	});
 }
 

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -443,7 +443,7 @@ macro_rules! uint_full_mul_reg {
 		unroll! {
 			for i in 0..$n_dwords {
 				// We rely on these if-statements being eliminated by the compiler for large numbers
-				// (numbers where log(n) base 2^64 > $n_dwords / 2).
+				// (numbers where log(me * you) base 2^64 > $n_dwords).
 				if i < $other_dwords {
 					let mut carry = 0u64;
 					let (b_u, b_l) = split(you[i]);

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -444,13 +444,13 @@ macro_rules! uint_full_mul_reg {
 			for i in 0..$n_dwords {
 				// We rely on these if-statements being eliminated by the compiler for large numbers
 				// (numbers where log(n) base 2^64 > $n_dwords / 2).
-				if i < $self_dwords {
+				if i < $other_dwords {
 					let mut carry = 0u64;
 					let (b_u, b_l) = split(you[i]);
 
 					unroll! {
 						for j in 0..$n_dwords {
-							if j < $other_dwords {
+							if j < $self_dwords {
 								let a = split(me[j]);
 
 								// multiply parts

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -56,16 +56,16 @@ macro_rules! impl_map_from {
 
 #[cfg(not(all(asm_available, target_arch="x86_64")))]
 macro_rules! uint_overflowing_add {
-	($name:ident, $n_words:tt, $self_expr: expr, $other: expr) => ({
-		uint_overflowing_add_reg!($name, $n_words, $self_expr, $other)
+	($name:ident, $n_dwords:tt, $self_expr: expr, $other: expr) => ({
+		uint_overflowing_add_reg!($name, $n_dwords, $self_expr, $other)
 	})
 }
 
 macro_rules! uint_overflowing_add_reg {
-	($name:ident, $n_words:tt, $self_expr: expr, $other: expr) => ({
+	($name:ident, $n_dwords:tt, $self_expr: expr, $other: expr) => ({
 		uint_overflowing_binop!(
 			$name,
-			$n_words,
+			$n_dwords,
 			$self_expr,
 			$other,
 			u64::overflowing_add
@@ -75,10 +75,10 @@ macro_rules! uint_overflowing_add_reg {
 
 #[cfg(all(asm_available, target_arch="x86_64"))]
 macro_rules! uint_overflowing_add {
-	(U256, $n_words:tt, $self_expr: expr, $other: expr) => ({
-		let mut result: [u64; $n_words] = unsafe { ::core::mem::uninitialized() };
-		let self_t: &[u64; $n_words] = &$self_expr.0;
-		let other_t: &[u64; $n_words] = &$other.0;
+	(U256, $n_dwords:tt, $self_expr: expr, $other: expr) => ({
+		let mut result: [u64; $n_dwords] = unsafe { ::core::mem::uninitialized() };
+		let self_t: &[u64; $n_dwords] = &$self_expr.0;
+		let other_t: &[u64; $n_dwords] = &$other.0;
 
 		let overflow: u8;
 		unsafe {
@@ -98,10 +98,10 @@ macro_rules! uint_overflowing_add {
 		}
 		(U256(result), overflow != 0)
 	});
-	(U512, $n_words:tt, $self_expr: expr, $other: expr) => ({
-		let mut result: [u64; $n_words] = unsafe { ::core::mem::uninitialized() };
-		let self_t: &[u64; $n_words] = &$self_expr.0;
-		let other_t: &[u64; $n_words] = &$other.0;
+	(U512, $n_dwords:tt, $self_expr: expr, $other: expr) => ({
+		let mut result: [u64; $n_dwords] = unsafe { ::core::mem::uninitialized() };
+		let self_t: &[u64; $n_dwords] = &$self_expr.0;
+		let other_t: &[u64; $n_dwords] = &$other.0;
 
 		let overflow: u8;
 
@@ -144,29 +144,29 @@ macro_rules! uint_overflowing_add {
 		(U512(result), overflow != 0)
 	});
 
-	($name:ident, $n_words:tt, $self_expr: expr, $other: expr) => (
-		uint_overflowing_add_reg!($name, $n_words, $self_expr, $other)
+	($name:ident, $n_dwords:tt, $self_expr: expr, $other: expr) => (
+		uint_overflowing_add_reg!($name, $n_dwords, $self_expr, $other)
 	)
 }
 
 #[cfg(not(all(asm_available, target_arch="x86_64")))]
 macro_rules! uint_overflowing_sub {
-	($name:ident, $n_words:tt, $self_expr: expr, $other: expr) => ({
-		uint_overflowing_sub_reg!($name, $n_words, $self_expr, $other)
+	($name:ident, $n_dwords:tt, $self_expr: expr, $other: expr) => ({
+		uint_overflowing_sub_reg!($name, $n_dwords, $self_expr, $other)
 	})
 }
 
 macro_rules! uint_overflowing_binop {
-	($name:ident, $n_words:tt, $self_expr: expr, $other: expr, $fn:expr) => ({
+	($name:ident, $n_dwords:tt, $self_expr: expr, $other: expr, $fn:expr) => ({
 		let $name(ref me) = $self_expr;
 		let $name(ref you) = $other;
 
 		let mut ret = unsafe { ::core::mem::uninitialized() };
-		let ret_ptr = &mut ret as *mut [u64; $n_words] as *mut u64;
+		let ret_ptr = &mut ret as *mut [u64; $n_dwords] as *mut u64;
 		let mut carry = 0u64;
 
 		unroll! {
-			for i in 0..$n_words {
+			for i in 0..$n_dwords {
 				use ::core::ptr;
 
 				if carry != 0 {
@@ -200,10 +200,10 @@ macro_rules! uint_overflowing_binop {
 }
 
 macro_rules! uint_overflowing_sub_reg {
-	($name:ident, $n_words:tt, $self_expr: expr, $other: expr) => ({
+	($name:ident, $n_dwords:tt, $self_expr: expr, $other: expr) => ({
 		uint_overflowing_binop!(
 			$name,
-			$n_words,
+			$n_dwords,
 			$self_expr,
 			$other,
 			u64::overflowing_sub
@@ -213,10 +213,10 @@ macro_rules! uint_overflowing_sub_reg {
 
 #[cfg(all(asm_available, target_arch="x86_64"))]
 macro_rules! uint_overflowing_sub {
-	(U256, $n_words:tt, $self_expr: expr, $other: expr) => ({
-		let mut result: [u64; $n_words] = unsafe { ::core::mem::uninitialized() };
-		let self_t: &[u64; $n_words] = &$self_expr.0;
-		let other_t: &[u64; $n_words] = &$other.0;
+	(U256, $n_dwords:tt, $self_expr: expr, $other: expr) => ({
+		let mut result: [u64; $n_dwords] = unsafe { ::core::mem::uninitialized() };
+		let self_t: &[u64; $n_dwords] = &$self_expr.0;
+		let other_t: &[u64; $n_dwords] = &$other.0;
 
 		let overflow: u8;
 		unsafe {
@@ -235,10 +235,10 @@ macro_rules! uint_overflowing_sub {
 		}
 		(U256(result), overflow != 0)
 	});
-	(U512, $n_words:tt, $self_expr: expr, $other: expr) => ({
-		let mut result: [u64; $n_words] = unsafe { ::core::mem::uninitialized() };
-		let self_t: &[u64; $n_words] = &$self_expr.0;
-		let other_t: &[u64; $n_words] = &$other.0;
+	(U512, $n_dwords:tt, $self_expr: expr, $other: expr) => ({
+		let mut result: [u64; $n_dwords] = unsafe { ::core::mem::uninitialized() };
+		let self_t: &[u64; $n_dwords] = &$self_expr.0;
+		let other_t: &[u64; $n_dwords] = &$other.0;
 
 		let overflow: u8;
 
@@ -280,17 +280,17 @@ macro_rules! uint_overflowing_sub {
 		}
 		(U512(result), overflow != 0)
 	});
-	($name:ident, $n_words:tt, $self_expr: expr, $other: expr) => ({
-		uint_overflowing_sub_reg!($name, $n_words, $self_expr, $other)
+	($name:ident, $n_dwords:tt, $self_expr: expr, $other: expr) => ({
+		uint_overflowing_sub_reg!($name, $n_dwords, $self_expr, $other)
 	})
 }
 
 #[cfg(all(asm_available, target_arch="x86_64"))]
 macro_rules! uint_overflowing_mul {
-	(U256, $n_words: expr, $self_expr: expr, $other: expr) => ({
-		let mut result: [u64; $n_words] = unsafe { ::core::mem::uninitialized() };
-		let self_t: &[u64; $n_words] = &$self_expr.0;
-		let other_t: &[u64; $n_words] = &$other.0;
+	(U256, $n_dwords: expr, $self_expr: expr, $other: expr) => ({
+		let mut result: [u64; $n_dwords] = unsafe { ::core::mem::uninitialized() };
+		let self_t: &[u64; $n_dwords] = &$self_expr.0;
+		let other_t: &[u64; $n_dwords] = &$other.0;
 
 		let overflow: u64;
 		unsafe {
@@ -400,50 +400,74 @@ macro_rules! uint_overflowing_mul {
 		}
 		(U256(result), overflow > 0)
 	});
-	($name:ident, $n_words:tt, $self_expr: expr, $other: expr) => (
-		uint_overflowing_mul_reg!($name, $n_words, $self_expr, $other)
+	($name:ident, $n_dwords:tt, $self_expr: expr, $other: expr) => (
+		uint_overflowing_mul_reg!($name, $n_dwords, $self_expr, $other)
 	)
 }
 
 #[cfg(not(all(asm_available, target_arch="x86_64")))]
 macro_rules! uint_overflowing_mul {
-	($name:ident, $n_words:tt, $self_expr: expr, $other: expr) => ({
-		uint_overflowing_mul_reg!($name, $n_words, $self_expr, $other)
+	($name:ident, $n_dwords:tt, $self_expr: expr, $other: expr) => ({
+		uint_overflowing_mul_reg!($name, $n_dwords, $self_expr, $other)
 	})
 }
 
 macro_rules! uint_full_mul_reg {
-	($name:ident, $n_words:tt, $self_expr:expr, $other:expr) => ({{
+	($name:ident, $n_dwords:tt, $self_expr:expr, $other:expr) => (
+		uint_full_mul_reg!(
+			$name,
+			$n_dwords * 2,
+			$n_dwords,
+			$n_dwords,
+			$self_expr,
+			$n_dwords,
+			$other
+		)
+	);
+	(
+		$name:ident,
+		$out_dwords:expr,
+		$n_dwords:tt,
+		$self_dwords:expr,
+		$self_expr:expr,
+		$other_dwords:expr,
+		$other:expr
+	) => ({{
 		#![allow(unused_assignments)]
 
 		let $name(ref me) = $self_expr;
 		let $name(ref you) = $other;
-		let mut ret = [0u64; 2*$n_words];
+
+		let mut ret = [0u64; $out_dwords];
 
 		unroll! {
-			for i in 0..$n_words {
-				let mut carry = 0u64;
-				let (b_u, b_l) = split(you[i]);
+			for i in 0..$n_dwords {
+				// We rely on these if-statements being eliminated by the compiler for large numbers
+				// (numbers where log(n) base 2^64 > $n_dwords / 2).
+				if i < $self_dwords {
+					let mut carry = 0u64;
+					let (b_u, b_l) = split(you[i]);
 
-				unroll! {
-					for j in 0..$n_words {
-						if me[j] != 0 || carry != 0 {
-							let a = split(me[j]);
+					unroll! {
+						for j in 0..$n_dwords {
+							if j < $other_dwords {
+								let a = split(me[j]);
 
-							// multiply parts
-							let (c_l, overflow_l) = mul_u32(a, b_l, ret[i + j]);
-							let (c_u, overflow_u) = mul_u32(a, b_u, c_l >> 32);
-							ret[i + j] = (c_l & 0xFFFFFFFF) + (c_u << 32);
+								// multiply parts
+								let (c_l, overflow_l) = mul_u32(a, b_l, ret[i + j]);
+								let (c_u, overflow_u) = mul_u32(a, b_u, c_l >> 32);
+								ret[i + j] = (c_l & 0xFFFFFFFF) + (c_u << 32);
 
-							// No overflow here
-							let res = (c_u >> 32) + (overflow_u << 32);
-							// possible overflows
-							let (res, o1) = res.overflowing_add(overflow_l + carry);
-							let (res, o2) = res.overflowing_add(ret[i + j + 1]);
-							ret[i + j + 1] = res;
+								// No overflow here
+								let res = (c_u >> 32) + (overflow_u << 32);
+								// possible overflows
+								let (res, o1) = res.overflowing_add(overflow_l + carry);
+								let (res, o2) = res.overflowing_add(ret[i + j + 1]);
+								ret[i + j + 1] = res;
 
-							// Only single overflow possible there
-							carry = (o1 | o2) as u64;
+								// Only single overflow possible there
+								carry = (o1 | o2) as u64;
+							}
 						}
 					}
 				}
@@ -454,28 +478,106 @@ macro_rules! uint_full_mul_reg {
 	}})
 }
 
+macro_rules! out_dwords {
+	($arr:expr, 2) => {
+		if $arr[1] != 0 {
+			2
+		} else if $arr[0] != 0 {
+			1
+		} else {
+			0
+		}
+	};
+	($arr:expr, 4) => {
+		if $arr[3] != 0 {
+			4
+		} else if $arr[2] != 0 {
+			3
+		} else if $arr[1] != 0 {
+			2
+		} else if $arr[0] != 0 {
+			1
+		} else {
+			0
+		}
+	};
+	($arr:expr, 8) => {
+		if $arr[7] != 0 {
+			8
+		} else if $arr[6] != 0 {
+			7
+		} else if $arr[5] != 0 {
+			6
+		} else if $arr[4] != 0 {
+			5
+		} else if $arr[3] != 0 {
+			4
+		} else if $arr[2] != 0 {
+			3
+		} else if $arr[1] != 0 {
+			2
+		} else if $arr[0] != 0 {
+			1
+		} else {
+			0
+		}
+	};
+}
+
 macro_rules! uint_overflowing_mul_reg {
-	($name:ident, $n_words:tt, $self_expr: expr, $other: expr) => ({
-		let ret: [u64; $n_words * 2] = uint_full_mul_reg!($name, $n_words, $self_expr, $other);
+	($name:ident, $n_dwords:tt, $self_expr: expr, $other: expr) => ({
+		#![allow(unused_assignments)]
 
-		// The safety of this is enforced by the compiler
-		let ret: [[u64; $n_words]; 2] = unsafe { mem::transmute(ret) };
+		let $name(ref me) = $self_expr;
+		let $name(ref you) = $other;
 
-		// The compiler WILL NOT inline this if you remove this annotation.
-		#[inline(always)]
-		fn any_nonzero(arr: &[u64; $n_words]) -> bool {
-			unroll! {
-				for i in 0..$n_words {
-					if arr[i] != 0 {
-						return true;
+		let (self_dwords, other_dwords) = (out_dwords!(me, $n_dwords), out_dwords!(you, $n_dwords));
+		let out_dwords = self_dwords + other_dwords;
+
+		// This is a safe optimization, since it's based on basic logarithmic rules.
+		// `log(a * b) = log(a) + log(b)`. This specific scenario would be log base `2^64`
+		if out_dwords <= $n_dwords {
+			(
+				$name(
+					uint_full_mul_reg!(
+						$name,
+						$n_dwords,
+						$n_dwords,
+						self_dwords,
+						$self_expr,
+						other_dwords,
+						$other
+					)
+				),
+				false,
+			)
+		} else {
+			let ret: [u64; $n_dwords * 2] = uint_full_mul_reg!(
+				$name,
+				$n_dwords,
+				$self_expr,
+				$other
+			);
+
+			// The safety of this is enforced by the compiler
+			let ret: [[u64; $n_dwords]; 2] = unsafe { mem::transmute(ret) };
+
+			// The compiler WILL NOT inline this if you remove this annotation.
+			#[inline(always)]
+			fn any_nonzero(arr: &[u64; $n_dwords]) -> bool {
+				unroll! {
+					for i in 0..$n_dwords {
+						if arr[i] != 0 {
+							return true;
+						}
 					}
 				}
+
+				false
 			}
 
-			false
+			($name(ret[0]), any_nonzero(&ret[1]))
 		}
-
-		($name(ret[0]), any_nonzero(&ret[1]))
 	})
 }
 
@@ -521,11 +623,11 @@ fn split(a: u64) -> (u64, u64) {
 }
 
 macro_rules! construct_uint {
-	($name:ident, $n_words:tt) => (
+	($name:ident, $n_dwords:tt) => (
 		/// Little-endian large integer type
 		#[repr(C)]
 		#[derive(Copy, Clone, Eq, PartialEq, Hash)]
-		pub struct $name(pub [u64; $n_words]);
+		pub struct $name(pub [u64; $n_dwords]);
 
 		impl $name {
 			/// Convert from a decimal string.
@@ -585,7 +687,7 @@ macro_rules! construct_uint {
 			#[inline]
 			pub fn as_u64(&self) -> u64 {
 				let &$name(ref arr) = self;
-				for i in 1..$n_words {
+				for i in 1..$n_dwords {
 					if arr[i] != 0 {
 						panic!("Integer overflow when casting U256")
 					}
@@ -597,7 +699,7 @@ macro_rules! construct_uint {
 			#[inline]
 			pub fn is_zero(&self) -> bool {
 				let &$name(ref arr) = self;
-				for i in 0..$n_words { if arr[i] != 0 { return false; } }
+				for i in 0..$n_dwords { if arr[i] != 0 { return false; } }
 				return true;
 			}
 
@@ -605,8 +707,8 @@ macro_rules! construct_uint {
 			#[inline]
 			pub fn bits(&self) -> usize {
 				let &$name(ref arr) = self;
-				for i in 1..$n_words {
-					if arr[$n_words - i] > 0 { return (0x40 * ($n_words - i + 1)) - arr[$n_words - i].leading_zeros() as usize; }
+				for i in 1..$n_dwords {
+					if arr[$n_dwords - i] > 0 { return (0x40 * ($n_dwords - i + 1)) - arr[$n_dwords - i].leading_zeros() as usize; }
 				}
 				0x40 - arr[0].leading_zeros() as usize
 			}
@@ -636,17 +738,17 @@ macro_rules! construct_uint {
 			/// Write to the slice in big-endian format.
 			#[inline]
 			pub fn to_big_endian(&self, bytes: &mut [u8]) {
-				debug_assert!($n_words * 8 == bytes.len());
-				for i in 0..$n_words {
-					BigEndian::write_u64(&mut bytes[8 * i..], self.0[$n_words - i - 1]);
+				debug_assert!($n_dwords * 8 == bytes.len());
+				for i in 0..$n_dwords {
+					BigEndian::write_u64(&mut bytes[8 * i..], self.0[$n_dwords - i - 1]);
 				}
 			}
 
 			/// Write to the slice in little-endian format.
 			#[inline]
 			pub fn to_little_endian(&self, bytes: &mut [u8]) {
-				debug_assert!($n_words * 8 == bytes.len());
-				for i in 0..$n_words {
+				debug_assert!($n_dwords * 8 == bytes.len());
+				for i in 0..$n_dwords {
 					LittleEndian::write_u64(&mut bytes[8 * i..], self.0[i]);
 				}
 			}
@@ -659,7 +761,7 @@ macro_rules! construct_uint {
 				use rustc_hex::ToHex;;
 
 				if self.is_zero() { return "0".to_owned(); }	// special case.
-				let mut bytes = [0u8; 8 * $n_words];
+				let mut bytes = [0u8; 8 * $n_dwords];
 				self.to_big_endian(&mut bytes);
 				let bp7 = self.bits() + 7;
 				let len = cmp::max(bp7 / 8, 1);
@@ -695,8 +797,8 @@ macro_rules! construct_uint {
 			/// The maximum value which can be inhabited by this type.
 			#[inline]
 			pub fn max_value() -> Self {
-				let mut result = [0; $n_words];
-				for i in 0..$n_words {
+				let mut result = [0; $n_dwords];
+				for i in 0..$n_dwords {
 					result[i] = u64::max_value();
 				}
 				$name(result)
@@ -726,7 +828,7 @@ macro_rules! construct_uint {
 						y = x * y;
 						x = x * x;
 						// to reduce odd number by 1 we should just clear the last bit
-						n.0[$n_words-1] = n.0[$n_words-1] & ((!0u64)>>1);
+						n.0[$n_dwords-1] = n.0[$n_dwords-1] & ((!0u64)>>1);
 						n = n >> 1;
 					}
 				}
@@ -763,7 +865,7 @@ macro_rules! construct_uint {
 			/// Optimized instructions
 			#[inline(always)]
 			pub fn overflowing_add(self, other: $name) -> ($name, bool) {
-				uint_overflowing_add!($name, $n_words, self, other)
+				uint_overflowing_add!($name, $n_dwords, self, other)
 			}
 
 			/// Addition which saturates at the maximum value.
@@ -777,7 +879,7 @@ macro_rules! construct_uint {
 			/// Subtraction which underflows and returns a flag if it does.
 			#[inline(always)]
 			pub fn overflowing_sub(self, other: $name) -> ($name, bool) {
-				uint_overflowing_sub!($name, $n_words, self, other)
+				uint_overflowing_sub!($name, $n_dwords, self, other)
 			}
 
 			/// Subtraction which saturates at zero.
@@ -791,7 +893,7 @@ macro_rules! construct_uint {
 			/// Multiply with overflow, returning a flag if it does.
 			#[inline(always)]
 			pub fn overflowing_mul(self, other: $name) -> ($name, bool) {
-				uint_overflowing_mul!($name, $n_words, self, other)
+				uint_overflowing_mul!($name, $n_dwords, self, other)
 			}
 
 			/// Multiplication which saturates at the maximum value..
@@ -829,11 +931,11 @@ macro_rules! construct_uint {
 			#[allow(dead_code)] // not used when multiplied with inline assembly
 			fn overflowing_mul_u32(self, other: u32) -> (Self, bool) {
 				let $name(ref arr) = self;
-				let mut ret = [0u64; $n_words];
+				let mut ret = [0u64; $n_dwords];
 				let mut carry = 0;
 				let o = other as u64;
 
-				for i in 0..$n_words {
+				for i in 0..$n_dwords {
 					let (res, carry2) = mul_u32(split(arr[i]), o, carry);
 					ret[i] = res;
 					carry = carry2;
@@ -846,11 +948,11 @@ macro_rules! construct_uint {
 			/// Can also be used as (&slice).into(), as it is default `From`
 			/// slice implementation for U256
 			pub fn from_big_endian(slice: &[u8]) -> Self {
-				assert!($n_words * 8 >= slice.len());
+				assert!($n_dwords * 8 >= slice.len());
 
-				let mut ret = [0; $n_words];
+				let mut ret = [0; $n_dwords];
 				unsafe {
-					let ret_u8: &mut [u8; $n_words * 8] = mem::transmute(&mut ret);
+					let ret_u8: &mut [u8; $n_dwords * 8] = mem::transmute(&mut ret);
 					let mut ret_ptr = ret_u8.as_mut_ptr();
 					let mut slice_ptr = slice.as_ptr().offset(slice.len() as isize - 1);
 					for _ in 0..slice.len() {
@@ -865,11 +967,11 @@ macro_rules! construct_uint {
 
 			/// Converts from little endian representation bytes in memory
 			pub fn from_little_endian(slice: &[u8]) -> Self {
-				assert!($n_words * 8 >= slice.len());
+				assert!($n_dwords * 8 >= slice.len());
 
-				let mut ret = [0; $n_words];
+				let mut ret = [0; $n_dwords];
 				unsafe {
-					let ret_u8: &mut [u8; $n_words * 8] = mem::transmute(&mut ret);
+					let ret_u8: &mut [u8; $n_dwords * 8] = mem::transmute(&mut ret);
 					ret_u8[0..slice.len()].copy_from_slice(&slice);
 				}
 
@@ -885,7 +987,7 @@ macro_rules! construct_uint {
 
 		impl From<u64> for $name {
 			fn from(value: u64) -> $name {
-				let mut ret = [0; $n_words];
+				let mut ret = [0; $n_dwords];
 				ret[0] = value;
 				$name(ret)
 			}
@@ -938,6 +1040,7 @@ macro_rules! construct_uint {
 		impl Add<$name> for $name {
 			type Output = $name;
 
+			#[inline(always)]
 			fn add(self, other: $name) -> $name {
 				let (result, overflow) = self.overflowing_add(other);
 				panic_on_overflow!(overflow);
@@ -948,7 +1051,7 @@ macro_rules! construct_uint {
 		impl Sub<$name> for $name {
 			type Output = $name;
 
-			#[inline]
+			#[inline(always)]
 			fn sub(self, other: $name) -> $name {
 				let (result, overflow) = self.overflowing_sub(other);
 				panic_on_overflow!(overflow);
@@ -959,6 +1062,7 @@ macro_rules! construct_uint {
 		impl Mul<$name> for $name {
 			type Output = $name;
 
+			#[inline(always)]
 			fn mul(self, other: $name) -> $name {
 				let (result, overflow) = self.overflowing_mul(other);
 				panic_on_overflow!(overflow);
@@ -972,7 +1076,7 @@ macro_rules! construct_uint {
 			fn div(self, other: $name) -> $name {
 				let mut sub_copy = self;
 				let mut shift_copy = other;
-				let mut ret = [0u64; $n_words];
+				let mut ret = [0u64; $n_dwords];
 
 				let my_bits = self.bits();
 				let your_bits = other.bits();
@@ -1018,8 +1122,8 @@ macro_rules! construct_uint {
 			fn bitand(self, other: $name) -> $name {
 				let $name(ref arr1) = self;
 				let $name(ref arr2) = other;
-				let mut ret = [0u64; $n_words];
-				for i in 0..$n_words {
+				let mut ret = [0u64; $n_dwords];
+				for i in 0..$n_dwords {
 					ret[i] = arr1[i] & arr2[i];
 				}
 				$name(ret)
@@ -1033,8 +1137,8 @@ macro_rules! construct_uint {
 			fn bitxor(self, other: $name) -> $name {
 				let $name(ref arr1) = self;
 				let $name(ref arr2) = other;
-				let mut ret = [0u64; $n_words];
-				for i in 0..$n_words {
+				let mut ret = [0u64; $n_dwords];
+				for i in 0..$n_dwords {
 					ret[i] = arr1[i] ^ arr2[i];
 				}
 				$name(ret)
@@ -1048,8 +1152,8 @@ macro_rules! construct_uint {
 			fn bitor(self, other: $name) -> $name {
 				let $name(ref arr1) = self;
 				let $name(ref arr2) = other;
-				let mut ret = [0u64; $n_words];
-				for i in 0..$n_words {
+				let mut ret = [0u64; $n_dwords];
+				for i in 0..$n_dwords {
 					ret[i] = arr1[i] | arr2[i];
 				}
 				$name(ret)
@@ -1062,8 +1166,8 @@ macro_rules! construct_uint {
 			#[inline]
 			fn not(self) -> $name {
 				let $name(ref arr) = self;
-				let mut ret = [0u64; $n_words];
-				for i in 0..$n_words {
+				let mut ret = [0u64; $n_dwords];
+				for i in 0..$n_dwords {
 					ret[i] = !arr[i];
 				}
 				$name(ret)
@@ -1073,19 +1177,20 @@ macro_rules! construct_uint {
 		impl Shl<usize> for $name {
 			type Output = $name;
 
+            #[inline]
 			fn shl(self, shift: usize) -> $name {
 				let $name(ref original) = self;
-				let mut ret = [0u64; $n_words];
+				let mut ret = [0u64; $n_dwords];
 				let word_shift = shift / 64;
 				let bit_shift = shift % 64;
 
 				// shift
-				for i in word_shift..$n_words {
+				for i in word_shift..$n_dwords {
 					ret[i] = original[i - word_shift] << bit_shift;
 				}
 				// carry
 				if bit_shift > 0 {
-					for i in word_shift+1..$n_words {
+					for i in word_shift+1..$n_dwords {
 						ret[i] += original[i - 1 - word_shift] >> (64 - bit_shift);
 					}
 				}
@@ -1096,20 +1201,21 @@ macro_rules! construct_uint {
 		impl Shr<usize> for $name {
 			type Output = $name;
 
+            #[inline]
 			fn shr(self, shift: usize) -> $name {
 				let $name(ref original) = self;
-				let mut ret = [0u64; $n_words];
+				let mut ret = [0u64; $n_dwords];
 				let word_shift = shift / 64;
 				let bit_shift = shift % 64;
 
 				// shift
-				for i in word_shift..$n_words {
+				for i in word_shift..$n_dwords {
 					ret[i - word_shift] = original[i] >> bit_shift;
 				}
 
 				// Carry
 				if bit_shift > 0 {
-					for i in word_shift+1..$n_words {
+					for i in word_shift+1..$n_dwords {
 						ret[i - word_shift - 1] += original[i] << (64 - bit_shift);
 					}
 				}
@@ -1122,7 +1228,7 @@ macro_rules! construct_uint {
 			fn cmp(&self, other: &$name) -> ::core::cmp::Ordering {
 				let &$name(ref me) = self;
 				let &$name(ref you) = other;
-				let mut i = $n_words;
+				let mut i = $n_dwords;
 				while i > 0 {
 					i -= 1;
 					if me[i] < you[i] { return ::core::cmp::Ordering::Less; }

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -478,7 +478,7 @@ macro_rules! uint_full_mul_reg {
 	}})
 }
 
-macro_rules! out_dwords {
+macro_rules! num_dwords {
 	($arr:expr, 2) => {
 		if $arr[1] != 0 {
 			2
@@ -531,7 +531,7 @@ macro_rules! uint_overflowing_mul_reg {
 		let $name(ref me) = $self_expr;
 		let $name(ref you) = $other;
 
-		let (self_dwords, other_dwords) = (out_dwords!(me, $n_dwords), out_dwords!(you, $n_dwords));
+		let (self_dwords, other_dwords) = (num_dwords!(me, $n_dwords), num_dwords!(you, $n_dwords));
 		let out_dwords = self_dwords + other_dwords;
 
 		// This is a safe optimization, since it's based on basic logarithmic rules.

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -56,16 +56,16 @@ macro_rules! impl_map_from {
 
 #[cfg(not(all(asm_available, target_arch="x86_64")))]
 macro_rules! uint_overflowing_add {
-	($name:ident, $n_dwords:tt, $self_expr: expr, $other: expr) => ({
-		uint_overflowing_add_reg!($name, $n_dwords, $self_expr, $other)
+	($name:ident, $n_qwords:tt, $self_expr: expr, $other: expr) => ({
+		uint_overflowing_add_reg!($name, $n_qwords, $self_expr, $other)
 	})
 }
 
 macro_rules! uint_overflowing_add_reg {
-	($name:ident, $n_dwords:tt, $self_expr: expr, $other: expr) => ({
+	($name:ident, $n_qwords:tt, $self_expr: expr, $other: expr) => ({
 		uint_overflowing_binop!(
 			$name,
-			$n_dwords,
+			$n_qwords,
 			$self_expr,
 			$other,
 			u64::overflowing_add
@@ -75,10 +75,10 @@ macro_rules! uint_overflowing_add_reg {
 
 #[cfg(all(asm_available, target_arch="x86_64"))]
 macro_rules! uint_overflowing_add {
-	(U256, $n_dwords:tt, $self_expr: expr, $other: expr) => ({
-		let mut result: [u64; $n_dwords] = unsafe { ::core::mem::uninitialized() };
-		let self_t: &[u64; $n_dwords] = &$self_expr.0;
-		let other_t: &[u64; $n_dwords] = &$other.0;
+	(U256, $n_qwords:tt, $self_expr: expr, $other: expr) => ({
+		let mut result: [u64; $n_qwords] = unsafe { ::core::mem::uninitialized() };
+		let self_t: &[u64; $n_qwords] = &$self_expr.0;
+		let other_t: &[u64; $n_qwords] = &$other.0;
 
 		let overflow: u8;
 		unsafe {
@@ -98,10 +98,10 @@ macro_rules! uint_overflowing_add {
 		}
 		(U256(result), overflow != 0)
 	});
-	(U512, $n_dwords:tt, $self_expr: expr, $other: expr) => ({
-		let mut result: [u64; $n_dwords] = unsafe { ::core::mem::uninitialized() };
-		let self_t: &[u64; $n_dwords] = &$self_expr.0;
-		let other_t: &[u64; $n_dwords] = &$other.0;
+	(U512, $n_qwords:tt, $self_expr: expr, $other: expr) => ({
+		let mut result: [u64; $n_qwords] = unsafe { ::core::mem::uninitialized() };
+		let self_t: &[u64; $n_qwords] = &$self_expr.0;
+		let other_t: &[u64; $n_qwords] = &$other.0;
 
 		let overflow: u8;
 
@@ -144,29 +144,29 @@ macro_rules! uint_overflowing_add {
 		(U512(result), overflow != 0)
 	});
 
-	($name:ident, $n_dwords:tt, $self_expr: expr, $other: expr) => (
-		uint_overflowing_add_reg!($name, $n_dwords, $self_expr, $other)
+	($name:ident, $n_qwords:tt, $self_expr: expr, $other: expr) => (
+		uint_overflowing_add_reg!($name, $n_qwords, $self_expr, $other)
 	)
 }
 
 #[cfg(not(all(asm_available, target_arch="x86_64")))]
 macro_rules! uint_overflowing_sub {
-	($name:ident, $n_dwords:tt, $self_expr: expr, $other: expr) => ({
-		uint_overflowing_sub_reg!($name, $n_dwords, $self_expr, $other)
+	($name:ident, $n_qwords:tt, $self_expr: expr, $other: expr) => ({
+		uint_overflowing_sub_reg!($name, $n_qwords, $self_expr, $other)
 	})
 }
 
 macro_rules! uint_overflowing_binop {
-	($name:ident, $n_dwords:tt, $self_expr: expr, $other: expr, $fn:expr) => ({
+	($name:ident, $n_qwords:tt, $self_expr: expr, $other: expr, $fn:expr) => ({
 		let $name(ref me) = $self_expr;
 		let $name(ref you) = $other;
 
 		let mut ret = unsafe { ::core::mem::uninitialized() };
-		let ret_ptr = &mut ret as *mut [u64; $n_dwords] as *mut u64;
+		let ret_ptr = &mut ret as *mut [u64; $n_qwords] as *mut u64;
 		let mut carry = 0u64;
 
 		unroll! {
-			for i in 0..$n_dwords {
+			for i in 0..$n_qwords {
 				use ::core::ptr;
 
 				if carry != 0 {
@@ -200,10 +200,10 @@ macro_rules! uint_overflowing_binop {
 }
 
 macro_rules! uint_overflowing_sub_reg {
-	($name:ident, $n_dwords:tt, $self_expr: expr, $other: expr) => ({
+	($name:ident, $n_qwords:tt, $self_expr: expr, $other: expr) => ({
 		uint_overflowing_binop!(
 			$name,
-			$n_dwords,
+			$n_qwords,
 			$self_expr,
 			$other,
 			u64::overflowing_sub
@@ -213,10 +213,10 @@ macro_rules! uint_overflowing_sub_reg {
 
 #[cfg(all(asm_available, target_arch="x86_64"))]
 macro_rules! uint_overflowing_sub {
-	(U256, $n_dwords:tt, $self_expr: expr, $other: expr) => ({
-		let mut result: [u64; $n_dwords] = unsafe { ::core::mem::uninitialized() };
-		let self_t: &[u64; $n_dwords] = &$self_expr.0;
-		let other_t: &[u64; $n_dwords] = &$other.0;
+	(U256, $n_qwords:tt, $self_expr: expr, $other: expr) => ({
+		let mut result: [u64; $n_qwords] = unsafe { ::core::mem::uninitialized() };
+		let self_t: &[u64; $n_qwords] = &$self_expr.0;
+		let other_t: &[u64; $n_qwords] = &$other.0;
 
 		let overflow: u8;
 		unsafe {
@@ -235,10 +235,10 @@ macro_rules! uint_overflowing_sub {
 		}
 		(U256(result), overflow != 0)
 	});
-	(U512, $n_dwords:tt, $self_expr: expr, $other: expr) => ({
-		let mut result: [u64; $n_dwords] = unsafe { ::core::mem::uninitialized() };
-		let self_t: &[u64; $n_dwords] = &$self_expr.0;
-		let other_t: &[u64; $n_dwords] = &$other.0;
+	(U512, $n_qwords:tt, $self_expr: expr, $other: expr) => ({
+		let mut result: [u64; $n_qwords] = unsafe { ::core::mem::uninitialized() };
+		let self_t: &[u64; $n_qwords] = &$self_expr.0;
+		let other_t: &[u64; $n_qwords] = &$other.0;
 
 		let overflow: u8;
 
@@ -280,17 +280,17 @@ macro_rules! uint_overflowing_sub {
 		}
 		(U512(result), overflow != 0)
 	});
-	($name:ident, $n_dwords:tt, $self_expr: expr, $other: expr) => ({
-		uint_overflowing_sub_reg!($name, $n_dwords, $self_expr, $other)
+	($name:ident, $n_qwords:tt, $self_expr: expr, $other: expr) => ({
+		uint_overflowing_sub_reg!($name, $n_qwords, $self_expr, $other)
 	})
 }
 
 #[cfg(all(asm_available, target_arch="x86_64"))]
 macro_rules! uint_overflowing_mul {
-	(U256, $n_dwords: expr, $self_expr: expr, $other: expr) => ({
-		let mut result: [u64; $n_dwords] = unsafe { ::core::mem::uninitialized() };
-		let self_t: &[u64; $n_dwords] = &$self_expr.0;
-		let other_t: &[u64; $n_dwords] = &$other.0;
+	(U256, $n_qwords: expr, $self_expr: expr, $other: expr) => ({
+		let mut result: [u64; $n_qwords] = unsafe { ::core::mem::uninitialized() };
+		let self_t: &[u64; $n_qwords] = &$self_expr.0;
+		let other_t: &[u64; $n_qwords] = &$other.0;
 
 		let overflow: u64;
 		unsafe {
@@ -400,37 +400,37 @@ macro_rules! uint_overflowing_mul {
 		}
 		(U256(result), overflow > 0)
 	});
-	($name:ident, $n_dwords:tt, $self_expr: expr, $other: expr) => (
-		uint_overflowing_mul_reg!($name, $n_dwords, $self_expr, $other)
+	($name:ident, $n_qwords:tt, $self_expr: expr, $other: expr) => (
+		uint_overflowing_mul_reg!($name, $n_qwords, $self_expr, $other)
 	)
 }
 
 #[cfg(not(all(asm_available, target_arch="x86_64")))]
 macro_rules! uint_overflowing_mul {
-	($name:ident, $n_dwords:tt, $self_expr: expr, $other: expr) => ({
-		uint_overflowing_mul_reg!($name, $n_dwords, $self_expr, $other)
+	($name:ident, $n_qwords:tt, $self_expr: expr, $other: expr) => ({
+		uint_overflowing_mul_reg!($name, $n_qwords, $self_expr, $other)
 	})
 }
 
 macro_rules! uint_full_mul_reg {
-	($name:ident, $n_dwords:tt, $self_expr:expr, $other:expr) => (
+	($name:ident, $n_qwords:tt, $self_expr:expr, $other:expr) => (
 		uint_full_mul_reg!(
 			$name,
-			$n_dwords * 2,
-			$n_dwords,
-			$n_dwords,
+			$n_qwords * 2,
+			$n_qwords,
+			$n_qwords,
 			$self_expr,
-			$n_dwords,
+			$n_qwords,
 			$other
 		)
 	);
 	(
 		$name:ident,
-		$out_dwords:expr,
-		$n_dwords:tt,
-		$self_dwords:expr,
+		$out_qwords:expr,
+		$n_qwords:tt,
+		$self_qwords:expr,
 		$self_expr:expr,
-		$other_dwords:expr,
+		$other_qwords:expr,
 		$other:expr
 	) => ({{
 		#![allow(unused_assignments)]
@@ -438,19 +438,19 @@ macro_rules! uint_full_mul_reg {
 		let $name(ref me) = $self_expr;
 		let $name(ref you) = $other;
 
-		let mut ret = [0u64; $out_dwords];
+		let mut ret = [0u64; $out_qwords];
 
 		unroll! {
-			for i in 0..$n_dwords {
+			for i in 0..$n_qwords {
 				// We rely on these if-statements being eliminated by the compiler for large numbers
-				// (numbers where log(me * you) base 2^64 > $n_dwords).
-				if i < $other_dwords {
+				// (numbers where log(me * you) base 2^64 > $n_qwords).
+				if i < $other_qwords {
 					let mut carry = 0u64;
 					let (b_u, b_l) = split(you[i]);
 
 					unroll! {
-						for j in 0..$n_dwords {
-							if j < $self_dwords {
+						for j in 0..$n_qwords {
+							if j < $self_qwords {
 								let a = split(me[j]);
 
 								// multiply parts
@@ -478,7 +478,7 @@ macro_rules! uint_full_mul_reg {
 	}})
 }
 
-macro_rules! num_dwords {
+macro_rules! num_qwords {
 	($arr:expr, 4) => {
 		if $arr[3] != 0 {
 			4
@@ -516,26 +516,26 @@ macro_rules! num_dwords {
 }
 
 macro_rules! uint_overflowing_mul_reg {
-	($name:ident, $n_dwords:tt, $self_expr: expr, $other: expr) => ({
+	($name:ident, $n_qwords:tt, $self_expr: expr, $other: expr) => ({
 		#![allow(unused_assignments)]
 
 		// This is a safe optimization, since it's based on basic logarithmic rules.
 		// `log(a * b) = log(a) + log(b)`. This specific scenario would be log base `2^64`
-		let ret: [u64; $n_dwords * 2] = uint_full_mul_reg!(
+		let ret: [u64; $n_qwords * 2] = uint_full_mul_reg!(
 			$name,
-			$n_dwords,
+			$n_qwords,
 			$self_expr,
 			$other
 		);
 
 		// The safety of this is enforced by the compiler
-		let ret: [[u64; $n_dwords]; 2] = unsafe { mem::transmute(ret) };
+		let ret: [[u64; $n_qwords]; 2] = unsafe { mem::transmute(ret) };
 
 		// The compiler WILL NOT inline this if you remove this annotation.
 		#[inline(always)]
-		fn any_nonzero(arr: &[u64; $n_dwords]) -> bool {
+		fn any_nonzero(arr: &[u64; $n_qwords]) -> bool {
 			unroll! {
-				for i in 0..$n_dwords {
+				for i in 0..$n_qwords {
 					if arr[i] != 0 {
 						return true;
 					}
@@ -591,11 +591,11 @@ fn split(a: u64) -> (u64, u64) {
 }
 
 macro_rules! construct_uint {
-	($name:ident, $n_dwords:tt) => (
+	($name:ident, $n_qwords:tt) => (
 		/// Little-endian large integer type
 		#[repr(C)]
 		#[derive(Copy, Clone, Eq, PartialEq, Hash)]
-		pub struct $name(pub [u64; $n_dwords]);
+		pub struct $name(pub [u64; $n_qwords]);
 
 		impl $name {
 			/// Convert from a decimal string.
@@ -655,7 +655,7 @@ macro_rules! construct_uint {
 			#[inline]
 			pub fn as_u64(&self) -> u64 {
 				let &$name(ref arr) = self;
-				for i in 1..$n_dwords {
+				for i in 1..$n_qwords {
 					if arr[i] != 0 {
 						panic!("Integer overflow when casting U256")
 					}
@@ -667,7 +667,7 @@ macro_rules! construct_uint {
 			#[inline]
 			pub fn is_zero(&self) -> bool {
 				let &$name(ref arr) = self;
-				for i in 0..$n_dwords { if arr[i] != 0 { return false; } }
+				for i in 0..$n_qwords { if arr[i] != 0 { return false; } }
 				return true;
 			}
 
@@ -675,8 +675,8 @@ macro_rules! construct_uint {
 			#[inline]
 			pub fn bits(&self) -> usize {
 				let &$name(ref arr) = self;
-				for i in 1..$n_dwords {
-					if arr[$n_dwords - i] > 0 { return (0x40 * ($n_dwords - i + 1)) - arr[$n_dwords - i].leading_zeros() as usize; }
+				for i in 1..$n_qwords {
+					if arr[$n_qwords - i] > 0 { return (0x40 * ($n_qwords - i + 1)) - arr[$n_qwords - i].leading_zeros() as usize; }
 				}
 				0x40 - arr[0].leading_zeros() as usize
 			}
@@ -706,17 +706,17 @@ macro_rules! construct_uint {
 			/// Write to the slice in big-endian format.
 			#[inline]
 			pub fn to_big_endian(&self, bytes: &mut [u8]) {
-				debug_assert!($n_dwords * 8 == bytes.len());
-				for i in 0..$n_dwords {
-					BigEndian::write_u64(&mut bytes[8 * i..], self.0[$n_dwords - i - 1]);
+				debug_assert!($n_qwords * 8 == bytes.len());
+				for i in 0..$n_qwords {
+					BigEndian::write_u64(&mut bytes[8 * i..], self.0[$n_qwords - i - 1]);
 				}
 			}
 
 			/// Write to the slice in little-endian format.
 			#[inline]
 			pub fn to_little_endian(&self, bytes: &mut [u8]) {
-				debug_assert!($n_dwords * 8 == bytes.len());
-				for i in 0..$n_dwords {
+				debug_assert!($n_qwords * 8 == bytes.len());
+				for i in 0..$n_qwords {
 					LittleEndian::write_u64(&mut bytes[8 * i..], self.0[i]);
 				}
 			}
@@ -729,7 +729,7 @@ macro_rules! construct_uint {
 				use rustc_hex::ToHex;;
 
 				if self.is_zero() { return "0".to_owned(); }	// special case.
-				let mut bytes = [0u8; 8 * $n_dwords];
+				let mut bytes = [0u8; 8 * $n_qwords];
 				self.to_big_endian(&mut bytes);
 				let bp7 = self.bits() + 7;
 				let len = cmp::max(bp7 / 8, 1);
@@ -765,8 +765,8 @@ macro_rules! construct_uint {
 			/// The maximum value which can be inhabited by this type.
 			#[inline]
 			pub fn max_value() -> Self {
-				let mut result = [0; $n_dwords];
-				for i in 0..$n_dwords {
+				let mut result = [0; $n_qwords];
+				for i in 0..$n_qwords {
 					result[i] = u64::max_value();
 				}
 				$name(result)
@@ -796,7 +796,7 @@ macro_rules! construct_uint {
 						y = x * y;
 						x = x * x;
 						// to reduce odd number by 1 we should just clear the last bit
-						n.0[$n_dwords-1] = n.0[$n_dwords-1] & ((!0u64)>>1);
+						n.0[$n_qwords-1] = n.0[$n_qwords-1] & ((!0u64)>>1);
 						n = n >> 1;
 					}
 				}
@@ -833,7 +833,7 @@ macro_rules! construct_uint {
 			/// Optimized instructions
 			#[inline(always)]
 			pub fn overflowing_add(self, other: $name) -> ($name, bool) {
-				uint_overflowing_add!($name, $n_dwords, self, other)
+				uint_overflowing_add!($name, $n_qwords, self, other)
 			}
 
 			/// Addition which saturates at the maximum value.
@@ -847,7 +847,7 @@ macro_rules! construct_uint {
 			/// Subtraction which underflows and returns a flag if it does.
 			#[inline(always)]
 			pub fn overflowing_sub(self, other: $name) -> ($name, bool) {
-				uint_overflowing_sub!($name, $n_dwords, self, other)
+				uint_overflowing_sub!($name, $n_qwords, self, other)
 			}
 
 			/// Subtraction which saturates at zero.
@@ -861,7 +861,7 @@ macro_rules! construct_uint {
 			/// Multiply with overflow, returning a flag if it does.
 			#[inline(always)]
 			pub fn overflowing_mul(self, other: $name) -> ($name, bool) {
-				uint_overflowing_mul!($name, $n_dwords, self, other)
+				uint_overflowing_mul!($name, $n_qwords, self, other)
 			}
 
 			/// Multiplication which saturates at the maximum value..
@@ -899,11 +899,11 @@ macro_rules! construct_uint {
 			#[allow(dead_code)] // not used when multiplied with inline assembly
 			fn overflowing_mul_u32(self, other: u32) -> (Self, bool) {
 				let $name(ref arr) = self;
-				let mut ret = [0u64; $n_dwords];
+				let mut ret = [0u64; $n_qwords];
 				let mut carry = 0;
 				let o = other as u64;
 
-				for i in 0..$n_dwords {
+				for i in 0..$n_qwords {
 					let (res, carry2) = mul_u32(split(arr[i]), o, carry);
 					ret[i] = res;
 					carry = carry2;
@@ -916,11 +916,11 @@ macro_rules! construct_uint {
 			/// Can also be used as (&slice).into(), as it is default `From`
 			/// slice implementation for U256
 			pub fn from_big_endian(slice: &[u8]) -> Self {
-				assert!($n_dwords * 8 >= slice.len());
+				assert!($n_qwords * 8 >= slice.len());
 
-				let mut ret = [0; $n_dwords];
+				let mut ret = [0; $n_qwords];
 				unsafe {
-					let ret_u8: &mut [u8; $n_dwords * 8] = mem::transmute(&mut ret);
+					let ret_u8: &mut [u8; $n_qwords * 8] = mem::transmute(&mut ret);
 					let mut ret_ptr = ret_u8.as_mut_ptr();
 					let mut slice_ptr = slice.as_ptr().offset(slice.len() as isize - 1);
 					for _ in 0..slice.len() {
@@ -935,11 +935,11 @@ macro_rules! construct_uint {
 
 			/// Converts from little endian representation bytes in memory
 			pub fn from_little_endian(slice: &[u8]) -> Self {
-				assert!($n_dwords * 8 >= slice.len());
+				assert!($n_qwords * 8 >= slice.len());
 
-				let mut ret = [0; $n_dwords];
+				let mut ret = [0; $n_qwords];
 				unsafe {
-					let ret_u8: &mut [u8; $n_dwords * 8] = mem::transmute(&mut ret);
+					let ret_u8: &mut [u8; $n_qwords * 8] = mem::transmute(&mut ret);
 					ret_u8[0..slice.len()].copy_from_slice(&slice);
 				}
 
@@ -955,7 +955,7 @@ macro_rules! construct_uint {
 
 		impl From<u64> for $name {
 			fn from(value: u64) -> $name {
-				let mut ret = [0; $n_dwords];
+				let mut ret = [0; $n_qwords];
 				ret[0] = value;
 				$name(ret)
 			}
@@ -1044,7 +1044,7 @@ macro_rules! construct_uint {
 			fn div(self, other: $name) -> $name {
 				let mut sub_copy = self;
 				let mut shift_copy = other;
-				let mut ret = [0u64; $n_dwords];
+				let mut ret = [0u64; $n_qwords];
 
 				let my_bits = self.bits();
 				let your_bits = other.bits();
@@ -1090,8 +1090,8 @@ macro_rules! construct_uint {
 			fn bitand(self, other: $name) -> $name {
 				let $name(ref arr1) = self;
 				let $name(ref arr2) = other;
-				let mut ret = [0u64; $n_dwords];
-				for i in 0..$n_dwords {
+				let mut ret = [0u64; $n_qwords];
+				for i in 0..$n_qwords {
 					ret[i] = arr1[i] & arr2[i];
 				}
 				$name(ret)
@@ -1105,8 +1105,8 @@ macro_rules! construct_uint {
 			fn bitxor(self, other: $name) -> $name {
 				let $name(ref arr1) = self;
 				let $name(ref arr2) = other;
-				let mut ret = [0u64; $n_dwords];
-				for i in 0..$n_dwords {
+				let mut ret = [0u64; $n_qwords];
+				for i in 0..$n_qwords {
 					ret[i] = arr1[i] ^ arr2[i];
 				}
 				$name(ret)
@@ -1120,8 +1120,8 @@ macro_rules! construct_uint {
 			fn bitor(self, other: $name) -> $name {
 				let $name(ref arr1) = self;
 				let $name(ref arr2) = other;
-				let mut ret = [0u64; $n_dwords];
-				for i in 0..$n_dwords {
+				let mut ret = [0u64; $n_qwords];
+				for i in 0..$n_qwords {
 					ret[i] = arr1[i] | arr2[i];
 				}
 				$name(ret)
@@ -1134,8 +1134,8 @@ macro_rules! construct_uint {
 			#[inline]
 			fn not(self) -> $name {
 				let $name(ref arr) = self;
-				let mut ret = [0u64; $n_dwords];
-				for i in 0..$n_dwords {
+				let mut ret = [0u64; $n_qwords];
+				for i in 0..$n_qwords {
 					ret[i] = !arr[i];
 				}
 				$name(ret)
@@ -1148,17 +1148,17 @@ macro_rules! construct_uint {
             #[inline]
 			fn shl(self, shift: usize) -> $name {
 				let $name(ref original) = self;
-				let mut ret = [0u64; $n_dwords];
+				let mut ret = [0u64; $n_qwords];
 				let word_shift = shift / 64;
 				let bit_shift = shift % 64;
 
 				// shift
-				for i in word_shift..$n_dwords {
+				for i in word_shift..$n_qwords {
 					ret[i] = original[i - word_shift] << bit_shift;
 				}
 				// carry
 				if bit_shift > 0 {
-					for i in word_shift+1..$n_dwords {
+					for i in word_shift+1..$n_qwords {
 						ret[i] += original[i - 1 - word_shift] >> (64 - bit_shift);
 					}
 				}
@@ -1172,18 +1172,18 @@ macro_rules! construct_uint {
             #[inline]
 			fn shr(self, shift: usize) -> $name {
 				let $name(ref original) = self;
-				let mut ret = [0u64; $n_dwords];
+				let mut ret = [0u64; $n_qwords];
 				let word_shift = shift / 64;
 				let bit_shift = shift % 64;
 
 				// shift
-				for i in word_shift..$n_dwords {
+				for i in word_shift..$n_qwords {
 					ret[i - word_shift] = original[i] >> bit_shift;
 				}
 
 				// Carry
 				if bit_shift > 0 {
-					for i in word_shift+1..$n_dwords {
+					for i in word_shift+1..$n_qwords {
 						ret[i - word_shift - 1] += original[i] << (64 - bit_shift);
 					}
 				}
@@ -1196,7 +1196,7 @@ macro_rules! construct_uint {
 			fn cmp(&self, other: &$name) -> ::core::cmp::Ordering {
 				let &$name(ref me) = self;
 				let &$name(ref you) = other;
-				let mut i = $n_dwords;
+				let mut i = $n_qwords;
 				while i > 0 {
 					i -= 1;
 					if me[i] < you[i] { return ::core::cmp::Ordering::Less; }


### PR DESCRIPTION
So from discussion with @NikVolf it seems like some of our benchmarks were rather unrepresentative, so I've fixed up the multiplication code to less aggressively prefer 0 and other small numbers. We're now at faster-than-asm performance for the full multiplication and only slightly slower for overflowing multiplication when done over the full range of numbers (product of squares of all odd numbers between 0 and 10000, or more specifically the product of `(0..1000).map(|x| x | 1)`). I'm wondering whether we can make the overflowing multiplication slightly faster by adding a check in the loop something similar to

```rust
if index_about_to_be_set > $out_words / 2 && num_about_to_be_set != 0 {
    is_overflowing = true;
}
```

Maybe we'll want to put `&& !is_overflowing` in the condition to get better branch prediction, but we'd have to instrument it to make sure. The `index_about_to_be_set` check should be optimized out by const-folding.

Anyway, this should be an improvement over the multiplication that was included in the previous PR.

## Benchmarks:

[Old PR](https://github.com/paritytech/bigint/pull/26):

```
running 10 tests
test u128_mul      ... bench:      85,756 ns/iter (+/- 1,131)
test u256_add      ... bench:      33,537 ns/iter (+/- 17,619)
test u256_from_be  ... bench:          25 ns/iter (+/- 0)
test u256_from_le  ... bench:          11 ns/iter (+/- 1)
test u256_full_mul ... bench:     307,933 ns/iter (+/- 2,363)
test u256_mul      ... bench:     334,596 ns/iter (+/- 11,623)
test u256_sub      ... bench:      37,168 ns/iter (+/- 3,088)
test u512_add      ... bench:      30,430 ns/iter (+/- 509)
test u512_mul      ... bench:   1,387,942 ns/iter (+/- 158,007)
test u512_sub      ... bench:      31,861 ns/iter (+/- 571)
```

asm:

```
running 10 tests
test u128_mul      ... bench:     287,110 ns/iter (+/- 2,359)
test u256_add      ... bench:      43,413 ns/iter (+/- 668)
test u256_from_be  ... bench:          25 ns/iter (+/- 0)
test u256_from_le  ... bench:          11 ns/iter (+/- 0)
test u256_full_mul ... bench:     231,655 ns/iter (+/- 1,247)
test u256_mul      ... bench:     124,843 ns/iter (+/- 33,822)
test u256_sub      ... bench:      44,612 ns/iter (+/- 225)
test u512_add      ... bench:     107,818 ns/iter (+/- 656)
test u512_mul      ... bench:     806,559 ns/iter (+/- 64,862)
test u512_sub      ... bench:     174,912 ns/iter (+/- 21,225)
```

This PR:

```
running 10 tests
test u128_mul      ... bench:      76,520 ns/iter (+/- 6,218)
test u256_add      ... bench:      33,468 ns/iter (+/- 2,700)
test u256_from_be  ... bench:          25 ns/iter (+/- 0)
test u256_from_le  ... bench:          11 ns/iter (+/- 1)
test u256_full_mul ... bench:     212,304 ns/iter (+/- 18,580)
test u256_mul      ... bench:     144,798 ns/iter (+/- 3,291)
test u256_sub      ... bench:      37,195 ns/iter (+/- 722)
test u512_add      ... bench:      30,443 ns/iter (+/- 2,172)
test u512_mul      ... bench:     211,607 ns/iter (+/- 4,644)
test u512_sub      ... bench:      31,866 ns/iter (+/- 582)
```

Benchcmp (old PR vs this PR):

```
 name           old.bench ns/iter  optimized.bench ns/iter  diff ns/iter   diff %  speedup 
 u128_mul       85,756             76,520                         -9,236  -10.77%   x 1.12 
 u256_add       33,537             33,468                            -69   -0.21%   x 1.00 
 u256_from_be   25                 25                                  0    0.00%   x 1.00 
 u256_from_le   11                 11                                  0    0.00%   x 1.00 
 u256_full_mul  307,933            212,304                       -95,629  -31.06%   x 1.45 
 u256_mul       334,596            144,798                      -189,798  -56.72%   x 2.31 
 u256_sub       37,168             37,195                             27    0.07%   x 1.00 
 u512_add       30,430             30,443                             13    0.04%   x 1.00 
 u512_mul       1,387,942          211,607                    -1,176,335  -84.75%   x 6.56 
 u512_sub       31,861             31,866                              5    0.02%   x 1.00 
```

Benchcmp (asm vs this PR):

```
 name           asm.bench ns/iter  optimized.bench ns/iter  diff ns/iter   diff %  speedup 
 u128_mul       287,110            76,520                       -210,590  -73.35%   x 3.75 
 u256_add       43,413             33,468                         -9,945  -22.91%   x 1.30 
 u256_from_be   25                 25                                  0    0.00%   x 1.00 
 u256_from_le   11                 11                                  0    0.00%   x 1.00 
 u256_full_mul  231,655            212,304                       -19,351   -8.35%   x 1.09 
 u256_mul       124,843            144,798                        19,955   15.98%   x 0.86 
 u256_sub       44,612             37,195                         -7,417  -16.63%   x 1.20 
 u512_add       107,818            30,443                        -77,375  -71.76%   x 3.54 
 u512_mul       806,559            211,607                      -594,952  -73.76%   x 3.81 
 u512_sub       174,912            31,866                       -143,046  -81.78%   x 5.49 
```