### PR TITLE
[WIP] Test basic algebraic laws with quickcheck

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,9 @@ heapsize = { version = "0.4", optional = true }
 byteorder = { version = "1", default-features = false }
 crunchy = "0.1.5"
 
+[dev-dependencies]
+quickcheck = "0.3"
+
 [features]
 heapsizeof = ["heapsize", "std"]
 std = ["rustc-hex"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,5 +27,9 @@ extern crate heapsize;
 #[cfg(feature="std")]
 extern crate core;
 
+#[cfg(test)]
+#[macro_use]
+extern crate quickcheck;
+
 pub mod uint;
 pub use ::uint::*;


### PR DESCRIPTION
This PR adds property-based testing with quickcheck for basic algebraic laws.

Currently this is only implemented for `U128` but if you think this is useful I can refactor it to generate the test cases for the other numeric types.