### PR TITLE
Optionally use assembly on stable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ authors = ["Parity Technologies <admin@parity.io>"]
 build = "build.rs"
 
 [build-dependencies]
-rustc_version = "0.2"
+cc = { version = "1.0.9", optional = true }
 
 [dependencies]
 rustc-hex = { version = "1.0", optional = true }
@@ -23,6 +23,7 @@ quickcheck = "0.4"
 [features]
 heapsizeof = ["heapsize", "std"]
 std = ["rustc-hex"]
+asm = ["cc"]
 
 [[example]]
 name = "modular"

--- a/bigint-asm/u256.c
+++ b/bigint-asm/u256.c
@@ -1,9 +1,6 @@
 #include <stdint.h>
 
-uint8_t u256add(
-                      uint64_t *first,
-                      uint64_t *second
-                      ) {
+uint8_t u256add(uint64_t *first, uint64_t *second) {
   uint8_t overflow;
 
   asm (
@@ -23,11 +20,7 @@ uint8_t u256add(
   return overflow;
 }
 
-uint64_t u256mul(
-                      uint64_t *first,
-                      uint64_t *second,
-                      uint64_t *out
-                      ) {
+uint64_t u256mul(uint64_t *first, uint64_t *second, uint64_t *out) {
   register uint64_t overflow asm("rcx");
   uint64_t result0, result1, result2, result3;
 

--- a/bigint-asm/u256.c
+++ b/bigint-asm/u256.c
@@ -1,0 +1,148 @@
+#include <stdint.h>
+
+uint8_t u256add(
+                      uint64_t *first,
+                      uint64_t *second
+                      ) {
+  uint8_t overflow;
+
+  asm (
+       "addq %2, (%1)\n  "
+       "adcq %3, 8(%1)\n  "
+       "adcq %4, 16(%1)\n  "
+       "adcq %5, 24(%1)\n  "
+       "setc %0"
+       : "=r"(overflow)
+       : "r"(first),
+         "r"(second[0]),
+         "r"(second[1]),
+         "r"(second[2]),
+         "r"(second[3])
+       );
+
+  return overflow;
+}
+
+uint64_t u256mul(
+                      uint64_t *first,
+                      uint64_t *second,
+                      uint64_t *out
+                      ) {
+  register uint64_t overflow asm("rcx");
+  uint64_t result0, result1, result2, result3;
+
+  // TODO: Could use movcc instead of jumpcc?
+  asm (
+    "movq %4, %%rax\n  "
+    "mulq %8\n  "
+    "movq %%rax, %0\n  "
+    "movq %%rdx, %1\n  "
+
+    "movq %4, %%rax\n  "
+    "mulq %9\n  "
+    "addq %%rax, %1\n  "
+    "adcq $0, %%rdx\n  "
+    "movq %%rdx, %2\n  "
+
+    "movq %4, %%rax\n  "
+    "mulq %10\n  "
+    "addq %%rax, %2\n  "
+    "adcq $0, %%rdx\n  "
+    "movq %%rdx, %3\n  "
+
+    "movq %4, %%rax\n  "
+    "mulq %11\n  "
+    "addq %%rax, %3\n  "
+    "adcq $0, %%rdx\n  "
+    "movq %%rdx, %%rcx\n  "
+
+    "movq %5, %%rax\n  "
+    "mulq %8\n  "
+    "addq %%rax, %1\n  "
+    "adcq %%rdx, %2\n  "
+    "adcq $0, %3\n  "
+    "adcq $0, %%rcx\n  "
+
+    "movq %5, %%rax\n  "
+    "mulq %9\n  "
+    "addq %%rax, %2\n  "
+    "adcq %%rdx, %3\n  "
+    "adcq $0, %%rcx\n  "
+    "adcq $0, %3\n  "
+    "adcq $0, %%rcx\n  "
+
+    "movq %5, %%rax\n  "
+    "mulq %10\n  "
+    "addq %%rax, %3\n  "
+    "adcq $0, %%rdx\n  "
+    "orq %%rdx, %%rcx\n  "
+
+    "movq %6, %%rax\n  "
+    "mulq %8\n  "
+    "addq %%rax, %2\n  "
+    "adcq %%rdx, %3\n  "
+    "adcq $0, %%rcx\n  "
+
+    "movq %6, %%rax\n  "
+    "mulq %9\n  "
+    "addq %%rax, %3\n  "
+    "adcq $0, %%rdx\n  "
+    "orq %%rdx, %%rcx\n  "
+
+    "movq %7, %%rax\n  "
+    "mulq %8\n  "
+    "addq %%rax, %3\n  "
+    "orq %%rdx, %%rcx\n  "
+
+    "cmpq $0, %%rcx\n  "
+    "jne 2f\n  "
+
+    "movq %7, %%rcx\n  "
+    "jrcxz 12f\n  "
+
+    "movq %11, %%rcx\n  "
+    "movq %10, %%rax\n  "
+    "orq %%rax, %%rcx\n  "
+    "movq %9, %%rax\n  "
+    "orq %%rax, %%rcx\n  "
+    "jmp 2f\n  "
+
+    "12:\n  "
+    "movq %11, %%rcx\n  "
+    "jrcxz 11f\n  "
+
+    "movq %6, %%rcx\n  "
+    "movq %5, %%rax\n  "
+    "or %%rax, %%rcx\n  "
+
+    "cmpq $0, %%rcx\n  "
+    "jne 2f\n  "
+
+    "11:\n  "
+    "movq %10, %%rcx\n  "
+    "jrcxz 2f\n  "
+    "movq %6, %%rcx\n  "
+
+    "2:\n  "
+    : /* %0 */ "=&r"(result0),
+      /* %1 */ "=&r"(result1),
+      /* %2 */ "=&r"(result2),
+      /* %3 */ "=&r"(result3)
+    : /* %4 */ "r"(first[0]),
+      /* %5 */ "r"(first[1]),
+      /* %6 */ "r"(first[2]),
+      /* %7 */ "r"(first[3]),
+
+      /* %8 */ "r"(second[0]),
+      /* %9 */ "r"(second[1]),
+      /* %10 */ "r"(second[2]),
+      /* %11 */ "r"(second[3])
+    : "rax", "rdx", "rcx");
+
+  out[0] = result0;
+  out[1] = result1;
+  out[2] = result2;
+  out[3] = result3;
+
+  return overflow;
+}

--- a/bigint-asm/u256.c
+++ b/bigint-asm/u256.c
@@ -21,116 +21,117 @@ uint8_t u256add(uint64_t *first, uint64_t *second) {
 }
 
 uint64_t u256mul(uint64_t *first, uint64_t *second, uint64_t *out) {
-  register uint64_t overflow asm("rcx");
+  uint64_t overflow;
   uint64_t result[4];
 
   // TODO: Could use movcc instead of jumpcc?
   asm (
-    "movq %4, %%rax\n  "
-    "mulq %8\n  "
-    "movq %%rax, %0\n  "
-    "movq %%rdx, %1\n  "
-
-    "movq %4, %%rax\n  "
+    "mov %5, %%rax\n  "
     "mulq %9\n  "
-    "addq %%rax, %1\n  "
-    "adcq $0, %%rdx\n  "
-    "movq %%rdx, %2\n  "
+    "mov %%rax, %1\n  "
+    "mov %%rdx, %2\n  "
 
-    "movq %4, %%rax\n  "
+    "mov %5, %%rax\n  "
     "mulq %10\n  "
-    "addq %%rax, %2\n  "
-    "adcq $0, %%rdx\n  "
-    "movq %%rdx, %3\n  "
+    "add %%rax, %2\n  "
+    "adc $0, %%rdx\n  "
+    "mov %%rdx, %3\n  "
 
-    "movq %4, %%rax\n  "
+    "mov %5, %%rax\n  "
     "mulq %11\n  "
-    "addq %%rax, %3\n  "
-    "adcq $0, %%rdx\n  "
-    "movq %%rdx, %%rcx\n  "
+    "add %%rax, %3\n  "
+    "adc $0, %%rdx\n  "
+    "mov %%rdx, %4\n  "
 
-    "movq %5, %%rax\n  "
-    "mulq %8\n  "
-    "addq %%rax, %1\n  "
-    "adcq %%rdx, %2\n  "
-    "adcq $0, %3\n  "
-    "adcq $0, %%rcx\n  "
+    "mov %5, %%rax\n  "
+    "mulq %12\n  "
+    "add %%rax, %4\n  "
+    "adc $0, %%rdx\n  "
+    "mov %%rdx, %0\n  "
 
-    "movq %5, %%rax\n  "
+    "mov %6, %%rax\n  "
     "mulq %9\n  "
-    "addq %%rax, %2\n  "
-    "adcq %%rdx, %3\n  "
-    "adcq $0, %%rcx\n  "
-    "adcq $0, %3\n  "
-    "adcq $0, %%rcx\n  "
+    "add %%rax, %2\n  "
+    "adc %%rdx, %3\n  "
+    "adc $0, %4\n  "
+    "adc $0, %0\n  "
 
-    "movq %5, %%rax\n  "
+    "mov %6, %%rax\n  "
     "mulq %10\n  "
-    "addq %%rax, %3\n  "
-    "adcq $0, %%rdx\n  "
-    "orq %%rdx, %%rcx\n  "
+    "add %%rax, %3\n  "
+    "adc %%rdx, %4\n  "
+    "adc $0, %0\n  "
+    "adc $0, %4\n  "
+    "adc $0, %0\n  "
 
-    "movq %6, %%rax\n  "
-    "mulq %8\n  "
-    "addq %%rax, %2\n  "
-    "adcq %%rdx, %3\n  "
-    "adcq $0, %%rcx\n  "
+    "mov %6, %%rax\n  "
+    "mulq %11\n  "
+    "add %%rax, %4\n  "
+    "adc $0, %%rdx\n  "
+    "or %%rdx, %0\n  "
 
-    "movq %6, %%rax\n  "
+    "mov %7, %%rax\n  "
     "mulq %9\n  "
-    "addq %%rax, %3\n  "
-    "adcq $0, %%rdx\n  "
-    "orq %%rdx, %%rcx\n  "
+    "add %%rax, %3\n  "
+    "adc %%rdx, %4\n  "
+    "adc $0, %0\n  "
 
-    "movq %7, %%rax\n  "
-    "mulq %8\n  "
-    "addq %%rax, %3\n  "
-    "orq %%rdx, %%rcx\n  "
+    "mov %7, %%rax\n  "
+    "mulq %10\n  "
+    "add %%rax, %4\n  "
+    "adc $0, %%rdx\n  "
+    "or %%rdx, %0\n  "
 
-    "cmpq $0, %%rcx\n  "
+    "mov %8, %%rax\n  "
+    "mulq %9\n  "
+    "add %%rax, %4\n  "
+    "or %%rdx, %0\n  "
+
+    "cmpq $0, %0\n  "
     "jne 2f\n  "
 
-    "movq %7, %%rcx\n  "
+    "mov %8, %0\n  "
     "jrcxz 12f\n  "
 
-    "movq %11, %%rcx\n  "
-    "movq %10, %%rax\n  "
-    "orq %%rax, %%rcx\n  "
-    "movq %9, %%rax\n  "
-    "orq %%rax, %%rcx\n  "
+    "mov %12, %0\n  "
+    "mov %11, %%rax\n  "
+    "or %%rax, %0\n  "
+    "mov %10, %%rax\n  "
+    "or %%rax, %0\n  "
     "jmp 2f\n  "
 
     "12:\n  "
-    "movq %11, %%rcx\n  "
+    "mov %12, %0\n  "
     "jrcxz 11f\n  "
 
-    "movq %6, %%rcx\n  "
-    "movq %5, %%rax\n  "
-    "or %%rax, %%rcx\n  "
+    "mov %7, %0\n  "
+    "mov %6, %%rax\n  "
+    "or %%rax, %0\n  "
 
-    "cmpq $0, %%rcx\n  "
+    "cmpq $0, %0\n  "
     "jne 2f\n  "
 
     "11:\n  "
-    "movq %10, %%rcx\n  "
+    "mov %11, %0\n  "
     "jrcxz 2f\n  "
-    "movq %6, %%rcx\n  "
+    "mov %7, %0\n  "
 
     "2:\n  "
-    : /* %0 */ "=&r"(result[0]),
-      /* %1 */ "=&r"(result[1]),
-      /* %2 */ "=&r"(result[2]),
-      /* %3 */ "=&r"(result[3])
-    : /* %4 */ "r"(first[0]),
-      /* %5 */ "r"(first[1]),
-      /* %6 */ "r"(first[2]),
-      /* %7 */ "r"(first[3]),
+    : /* %0 */ "=r"(overflow),
+      /* %1 */ "=&r"(result[0]),
+      /* %2 */ "=&r"(result[1]),
+      /* %3 */ "=&r"(result[2]),
+      /* %4 */ "=&r"(result[3])
+    : /* %5 */ "r"(first[0]),
+      /* %6 */ "r"(first[1]),
+      /* %7 */ "r"(first[2]),
+      /* %8 */ "r"(first[3]),
 
-      /* %8 */ "r"(second[0]),
-      /* %9 */ "r"(second[1]),
-      /* %10 */ "r"(second[2]),
-      /* %11 */ "r"(second[3])
-    : "rax", "rdx", "rcx");
+      /* %9 */ "r"(second[0]),
+      /* %10 */ "r"(second[1]),
+      /* %11 */ "r"(second[2]),
+      /* %12 */ "r"(second[3])
+    : "rax", "rdx");
 
   out[0] = result[0];
   out[1] = result[1];

--- a/bigint-asm/u256.c
+++ b/bigint-asm/u256.c
@@ -22,7 +22,7 @@ uint8_t u256add(uint64_t *first, uint64_t *second) {
 
 uint64_t u256mul(uint64_t *first, uint64_t *second, uint64_t *out) {
   register uint64_t overflow asm("rcx");
-  uint64_t result0, result1, result2, result3;
+  uint64_t result[4];
 
   // TODO: Could use movcc instead of jumpcc?
   asm (
@@ -117,10 +117,10 @@ uint64_t u256mul(uint64_t *first, uint64_t *second, uint64_t *out) {
     "movq %6, %%rcx\n  "
 
     "2:\n  "
-    : /* %0 */ "=&r"(result0),
-      /* %1 */ "=&r"(result1),
-      /* %2 */ "=&r"(result2),
-      /* %3 */ "=&r"(result3)
+    : /* %0 */ "=&r"(result[0]),
+      /* %1 */ "=&r"(result[1]),
+      /* %2 */ "=&r"(result[2]),
+      /* %3 */ "=&r"(result[3])
     : /* %4 */ "r"(first[0]),
       /* %5 */ "r"(first[1]),
       /* %6 */ "r"(first[2]),
@@ -132,10 +132,10 @@ uint64_t u256mul(uint64_t *first, uint64_t *second, uint64_t *out) {
       /* %11 */ "r"(second[3])
     : "rax", "rdx", "rcx");
 
-  out[0] = result0;
-  out[1] = result1;
-  out[2] = result2;
-  out[3] = result3;
+  out[0] = result[0];
+  out[1] = result[1];
+  out[2] = result[2];
+  out[3] = result[3];
 
   return overflow;
 }

--- a/build.rs
+++ b/build.rs
@@ -6,12 +6,25 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-extern crate rustc_version;
+#[cfg(feature = "cc")]
+mod inner {
+	extern crate cc;
 
-use rustc_version::{version_meta, Channel};
+	pub fn main() {
+		cc::Build::new()
+			.file("./bigint-asm/u256.c")
+			.opt_level(3)
+			.static_flag(true)
+			.compile("u256");
+	}
+}
+
+#[cfg(not(feature = "cc"))]
+mod inner {
+	pub fn main() {
+	}
+}
 
 fn main() {
-	if let Channel::Nightly = version_meta().unwrap().channel {
-		println!("cargo:rustc-cfg=asm_available");
-	}
+	inner::main()
 }

--- a/build.rs
+++ b/build.rs
@@ -10,19 +10,71 @@
 mod inner {
 	extern crate cc;
 
+	macro_rules! redef {
+		($name:ident, $identifier:expr) => {
+			let $name = (stringify!($name), format!("{}_{}", stringify!($name), $identifier));
+		}
+	}
+
 	pub fn main() {
-		cc::Build::new()
+		use std::io::Write;
+
+		let identifier = {
+			use std::collections::hash_map::DefaultHasher;
+			use std::hash::{Hash, Hasher};
+
+			let mut hasher = DefaultHasher::new();
+			env!("CARGO_PKG_VERSION").hash(&mut hasher);
+			hasher.finish().to_string()
+		};
+
+		let mut builder = cc::Build::new();
+		builder
 			.file("./bigint-asm/u256.c")
 			.opt_level(3)
-			.static_flag(true)
-			.compile("u256");
+			.static_flag(true);
+
+		redef!(u256mul, identifier);
+		redef!(u256add, identifier);
+
+		for def in &[&u256mul, &u256add] {
+			builder.define(def.0, Some(def.1.as_ref()));
+		}
+
+		let mut out = ::std::fs::File::create(format!(
+			"{}/{}",
+			::std::env::var("OUT_DIR").unwrap(),
+			"/ffi.rs"
+		)).unwrap();
+
+    // TODO: Use bindgen?
+		write!(
+			out,
+			r#"
+mod inner {{
+	#[cfg(all(feature = "asm", target_arch = "x86_64"))]
+	extern "C" {{
+		// Currently, u256add is slower than the Rust implementation (assumably
+		// because of the overhead of calling a function with C calling convention),
+		// so we only use `u256mul` for now.
+
+		pub fn {u256mul_out}(first: *const u64, second: *const u64, out: *mut u64) -> u64;
+	}}
+}}
+
+pub use self::inner::{u256mul_out} as {u256mul};
+"#,
+			u256mul = u256mul.0,
+			u256mul_out = u256mul.1
+		).unwrap();
+
+		builder.compile("u256");
 	}
 }
 
 #[cfg(not(feature = "cc"))]
 mod inner {
-	pub fn main() {
-	}
+	pub fn main() {}
 }
 
 fn main() {

--- a/build.rs
+++ b/build.rs
@@ -18,11 +18,12 @@ mod inner {
 
 	pub fn main() {
 		use std::io::Write;
+		use std::fs::File;
+		use std::env;
+		use std::collections::hash_map::DefaultHasher;
+		use std::hash::{Hash, Hasher};
 
 		let identifier = {
-			use std::collections::hash_map::DefaultHasher;
-			use std::hash::{Hash, Hasher};
-
 			let mut hasher = DefaultHasher::new();
 			env!("CARGO_PKG_VERSION").hash(&mut hasher);
 			hasher.finish().to_string()
@@ -31,6 +32,7 @@ mod inner {
 		let mut builder = cc::Build::new();
 		builder
 			.file("./bigint-asm/u256.c")
+			.flag_if_supported("-march=native")
 			.opt_level(3)
 			.static_flag(true);
 
@@ -41,13 +43,13 @@ mod inner {
 			builder.define(def.0, Some(def.1.as_ref()));
 		}
 
-		let mut out = ::std::fs::File::create(format!(
+		let mut out = File::create(format!(
 			"{}/{}",
-			::std::env::var("OUT_DIR").unwrap(),
+			env::var("OUT_DIR").unwrap(),
 			"/ffi.rs"
 		)).unwrap();
 
-    // TODO: Use bindgen?
+		// TODO: Use bindgen?
 		write!(
 			out,
 			r#"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,8 +8,6 @@
 
 //! Efficient large, fixed-size big integers and hashes.
 
-#![cfg_attr(asm_available, feature(asm))]
-
 #![cfg_attr(not(feature="std"), no_std)]
 
 extern crate byteorder;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,9 +25,14 @@ extern crate heapsize;
 #[cfg(feature="std")]
 extern crate core;
 
-#[cfg(test)]
+#[cfg(all(feature = "std", test))]
 #[macro_use]
 extern crate quickcheck;
 
 pub mod uint;
 pub use ::uint::*;
+
+mod ffi {
+    include!(concat!(env!("OUT_DIR"), "/ffi.rs"));
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@ extern crate quickcheck;
 pub mod uint;
 pub use ::uint::*;
 
+#[cfg(feature = "asm")]
 mod ffi {
     include!(concat!(env!("OUT_DIR"), "/ffi.rs"));
 }

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -54,7 +54,7 @@ macro_rules! impl_map_from {
 	}
 }
 
-#[cfg(not(all(asm_available, target_arch="x86_64")))]
+#[cfg(not(all(feature = "asm", target_arch = "x86_64")))]
 macro_rules! uint_overflowing_add {
 	($name:ident, $n_words:tt, $self_expr: expr, $other: expr) => ({
 		uint_overflowing_add_reg!($name, $n_words, $self_expr, $other)
@@ -73,75 +73,22 @@ macro_rules! uint_overflowing_add_reg {
 	})
 }
 
-#[cfg(all(asm_available, target_arch="x86_64"))]
+#[cfg(all(feature = "asm", target_arch = "x86_64"))]
+extern "C" {
+	fn u256add(first: *mut u64, second: *const u64) -> u8;
+	fn u256mul(first: *const u64, second: *const u64, out: *mut u64) -> u64;
+}
+
+#[cfg(all(feature = "asm", target_arch = "x86_64"))]
 macro_rules! uint_overflowing_add {
 	(U256, $n_words:tt, $self_expr: expr, $other: expr) => ({
-		let mut result: [u64; $n_words] = unsafe { ::core::mem::uninitialized() };
-		let self_t: &[u64; $n_words] = &$self_expr.0;
-		let other_t: &[u64; $n_words] = &$other.0;
+		let mut self_t: [u64; $n_words] = $self_expr.0;
+		let other_t: [u64; $n_words] = $other.0;
 
-		let overflow: u8;
-		unsafe {
-			asm!("
-				add $9, $0
-				adc $10, $1
-				adc $11, $2
-				adc $12, $3
-				setc %al
-				"
-			: "=r"(result[0]), "=r"(result[1]), "=r"(result[2]), "=r"(result[3]), "={al}"(overflow)
-			: "0"(self_t[0]), "1"(self_t[1]), "2"(self_t[2]), "3"(self_t[3]),
-			  "mr"(other_t[0]), "mr"(other_t[1]), "mr"(other_t[2]), "mr"(other_t[3])
-			:
-			:
-			);
-		}
-		(U256(result), overflow != 0)
-	});
-	(U512, $n_words:tt, $self_expr: expr, $other: expr) => ({
-		let mut result: [u64; $n_words] = unsafe { ::core::mem::uninitialized() };
-		let self_t: &[u64; $n_words] = &$self_expr.0;
-		let other_t: &[u64; $n_words] = &$other.0;
-
-		let overflow: u8;
-
-		unsafe {
-			asm!("
-				add $15, $0
-				adc $16, $1
-				adc $17, $2
-				adc $18, $3
-				lodsq
-				adc $11, %rax
-				stosq
-				lodsq
-				adc $12, %rax
-				stosq
-				lodsq
-				adc $13, %rax
-				stosq
-				lodsq
-				adc $14, %rax
-				stosq
-				setc %al
-
-				": "=r"(result[0]), "=r"(result[1]), "=r"(result[2]), "=r"(result[3]),
-
-			  "={al}"(overflow) /* $0 - $4 */
-
-            : "{rdi}"(&result[4] as *const u64) /* $5 */
-			  "{rsi}"(&other_t[4] as *const u64) /* $6 */
-			  "0"(self_t[0]), "1"(self_t[1]), "2"(self_t[2]), "3"(self_t[3]),
-		  	  "m"(self_t[4]), "m"(self_t[5]), "m"(self_t[6]), "m"(self_t[7]),
-			  /* $7 - $14 */
-
-			  "mr"(other_t[0]), "mr"(other_t[1]), "mr"(other_t[2]), "mr"(other_t[3]),
-              "m"(other_t[4]), "m"(other_t[5]), "m"(other_t[6]), "m"(other_t[7]) /* $15 - $22 */
-			: "rdi", "rsi"
-			:
-			);
-		}
-		(U512(result), overflow != 0)
+		let overflow: bool = unsafe {
+			u256add(self_t.as_mut_ptr(), other_t.as_ptr()) != 0
+		};
+		(U256(self_t), overflow)
 	});
 
 	($name:ident, $n_words:tt, $self_expr: expr, $other: expr) => (
@@ -285,119 +232,17 @@ macro_rules! uint_overflowing_sub {
 	})
 }
 
-#[cfg(all(asm_available, target_arch="x86_64"))]
+#[cfg(all(feature = "asm", target_arch = "x86_64"))]
 macro_rules! uint_overflowing_mul {
 	(U256, $n_words: expr, $self_expr: expr, $other: expr) => ({
 		let mut result: [u64; $n_words] = unsafe { ::core::mem::uninitialized() };
-		let self_t: &[u64; $n_words] = &$self_expr.0;
-		let other_t: &[u64; $n_words] = &$other.0;
+		let self_t: [u64; $n_words] = $self_expr.0;
+		let other_t: [u64; $n_words] = $other.0;
 
-		let overflow: u64;
-		unsafe {
-			asm!("
-				mov $5, %rax
-				mulq $9
-				mov %rax, $0
-				mov %rdx, $1
+	let overflow: u64 = unsafe {
+		u256mul(self_t.as_ptr(), other_t.as_ptr(), result.as_mut_ptr())
+	};
 
-				mov $5, %rax
-				mulq $10
-				add %rax, $1
-				adc $$0, %rdx
-				mov %rdx, $2
-
-				mov $5, %rax
-				mulq $11
-				add %rax, $2
-				adc $$0, %rdx
-				mov %rdx, $3
-
-				mov $5, %rax
-				mulq $12
-				add %rax, $3
-				adc $$0, %rdx
-				mov %rdx, %rcx
-
-				mov $6, %rax
-				mulq $9
-				add %rax, $1
-				adc %rdx, $2
-				adc $$0, $3
-				adc $$0, %rcx
-
-				mov $6, %rax
-				mulq $10
-				add %rax, $2
-				adc %rdx, $3
-				adc $$0, %rcx
-				adc $$0, $3
-				adc $$0, %rcx
-
-				mov $6, %rax
-				mulq $11
-				add %rax, $3
-				adc $$0, %rdx
-				or %rdx, %rcx
-
-				mov $7, %rax
-				mulq $9
-				add %rax, $2
-				adc %rdx, $3
-				adc $$0, %rcx
-
-				mov $7, %rax
-				mulq $10
-				add %rax, $3
-				adc $$0, %rdx
-				or %rdx, %rcx
-
-				mov $8, %rax
-				mulq $9
-				add %rax, $3
-				or %rdx, %rcx
-
-				cmpq $$0, %rcx
-				jne 2f
-
-				mov $8, %rcx
-				jrcxz 12f
-
-				mov $12, %rcx
-				mov $11, %rax
-				or %rax, %rcx
-				mov $10, %rax
-				or %rax, %rcx
-				jmp 2f
-
-				12:
-				mov $12, %rcx
-				jrcxz 11f
-
-				mov $7, %rcx
-				mov $6, %rax
-				or %rax, %rcx
-
-				cmpq $$0, %rcx
-				jne 2f
-
-				11:
-				mov $11, %rcx
-				jrcxz 2f
-				mov $7, %rcx
-
-				2:
-				"
-				: /* $0 */ "={r8}"(result[0]), /* $1 */ "={r9}"(result[1]), /* $2 */ "={r10}"(result[2]),
-				  /* $3 */ "={r11}"(result[3]), /* $4 */  "={rcx}"(overflow)
-
-				: /* $5 */ "m"(self_t[0]), /* $6 */ "m"(self_t[1]), /* $7 */  "m"(self_t[2]),
-				  /* $8 */ "m"(self_t[3]), /* $9 */ "m"(other_t[0]), /* $10 */ "m"(other_t[1]),
-				  /* $11 */ "m"(other_t[2]), /* $12 */ "m"(other_t[3])
-           		: "rax", "rdx"
-				:
-
-			);
-		}
 		(U256(result), overflow > 0)
 	});
 	($name:ident, $n_words:tt, $self_expr: expr, $other: expr) => (
@@ -405,7 +250,7 @@ macro_rules! uint_overflowing_mul {
 	)
 }
 
-#[cfg(not(all(asm_available, target_arch="x86_64")))]
+#[cfg(not(all(feature = "asm", target_arch = "x86_64")))]
 macro_rules! uint_overflowing_mul {
 	($name:ident, $n_words:tt, $self_expr: expr, $other: expr) => ({
 		uint_overflowing_mul_reg!($name, $n_words, $self_expr, $other)


### PR DESCRIPTION
This allows use of assembly on stable by binding to C. This is only an improvement for `mul`, since the increased speed from ASM is dwarfed by the overhead of calling a function otherwise. This method has the benefit of not requiring the `asm!` macro to be stablised (unlikely to be any time soon, since the syntax is tied to LLVM's syntax and LLVM doesn't guarantee that the syntax remains stable). This is approximately 10% faster for multiplication, and likely will only be useful for multiplication. You can imagine that if cross-language inlining lands (which it's weird that Rust doesn't support, it seems to be the only LLVM-based language that doesn't) this would be just as fast as using `asm!`. This flag isn't enabled by default, meaning that you must enable it manually.

In order to avoid name collisions from using multiple versions of the library, I generate code in the build script.